### PR TITLE
Various fixes for Alignment and Treebank editor forms

### DIFF
--- a/app.wsgi
+++ b/app.wsgi
@@ -1,9 +1,16 @@
-import os, sys
+import os, sys, site
 
 path = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(path)
 
-activate = path + '/flask/bin/activate_this.py'
-execfile(activate, dict(__file__=activate))
+# Add the site-packages of the chosen virtualenv to work with
+site.addsitedir(path + '/flask/lib/python3.4/site-packages')
+
+# Add the app's directory to the PYTHONPATH
+sys.path.append(path)
+
+# Activate your virtual env
+activate_env = os.path.expanduser(path + "/flask/bin/activate_this.py")
+execfile(activate_env, dict(__file__=activate_env))
 
 from app import app as application

--- a/app/configurations/alignment.py
+++ b/app/configurations/alignment.py
@@ -6,5 +6,6 @@ alignment = {
     "tokenization.xslt" : "/apps/static/xslt/segtok_to_align.xsl",
     "editorUrl" : "http://sosol.perseids.org/exist/rest/db/app/align-editsentence-perseids.xhtml?doc=REPLACE_DOC&s=1",
     "collection" : "urn:cite:perseus:align",
-    "altVersionUrl" : "http://sosol.perseids.org/exist/rest/db/app/align-entersentence-perseids.xhtml"
+    "altVersionUrl" : "http://sosol.perseids.org/exist/rest/db/app/align-entersentence-perseids.xhtml",
+    "workListUrl" : "http://sosol.perseids.org/exist/rest/db/xq/ctsworklist.xq?inv=annotsrc"
 }

--- a/app/configurations/alignment.py
+++ b/app/configurations/alignment.py
@@ -3,8 +3,8 @@
 alignment = {
     "endpoint.create" : "http://sosol.perseids.org/sosol/dmm_api/create/item/AlignmentCite/DOC_REPLACE",
     "tokenization.endpoint" : "http://services2.perseids.org/llt/segtok",
-    "tokenization.xslt" : "/static/xslt/segtok_to_align.xsl",
-    "editorUrl" : "http://sosol.perseids.org/exist/rest/db/app/align-editsentence-perseids-test.xhtml?doc=REPLACE_DOC&s=1",
+    "tokenization.xslt" : "/apps/static/xslt/segtok_to_align.xsl",
+    "editorUrl" : "http://sosol.perseids.org/exist/rest/db/app/align-editsentence-perseids.xhtml?doc=REPLACE_DOC&s=1",
     "collection" : "urn:cite:perseus:align",
     "altVersionUrl" : "http://sosol.perseids.org/exist/rest/db/app/align-entersentence-perseids.xhtml"
 }

--- a/app/configurations/alignment.py
+++ b/app/configurations/alignment.py
@@ -4,6 +4,7 @@ alignment = {
     "endpoint.create" : "http://sosol.perseids.org/sosol/dmm_api/create/item/AlignmentCite/DOC_REPLACE",
     "tokenization.endpoint" : "http://services2.perseids.org/llt/segtok",
     "tokenization.xslt" : "/static/xslt/segtok_to_align.xsl",
-    "editorUrl" : "http://localhost/exist/rest/db/app/align-editsentence-perseids-test.xhtml?doc=REPLACE_DOC&amp;s=1",
-    "collection" : "urn:cite:perseus:align"
+    "editorUrl" : "http://sosol.perseids.org/exist/rest/db/app/align-editsentence-perseids-test.xhtml?doc=REPLACE_DOC&s=1",
+    "collection" : "urn:cite:perseus:align",
+    "altVersionUrl" : "http://sosol.perseids.org/exist/rest/db/app/align-entersentence-perseids.xhtml"
 }

--- a/app/configurations/treebank.py
+++ b/app/configurations/treebank.py
@@ -6,9 +6,9 @@ treebank = {
 
     "tokenization.endpoint" : "http://services2.perseids.org/llt/segtok",
     "tokenization.params" : "xml inline split-tokens|splitting merge-tokens|merging shift-tokens|shifting inputtext|text remove_node[] go_to_root ns",
-    "tokenization.xslt" : "/static/xslt/segtok_to_tb.xsl",
+    "tokenization.xslt" : "/apps/static/xslt/segtok_to_tb.xsl",
 
-    "oa.xslt" : "/static/xslt/wrap_treebank.xsl",
+    "oa.xslt" : "/apps/static/xslt/wrap_treebank.xsl",
 
     "editor.url" : "http://www.perseids.org/tools/arethusa/app/#/perseids"
 }

--- a/app/configurations/treebank.py
+++ b/app/configurations/treebank.py
@@ -10,5 +10,6 @@ treebank = {
 
     "oa.xslt" : "/apps/static/xslt/wrap_treebank.xsl",
 
-    "editor.url" : "http://www.perseids.org/tools/arethusa/app/#/perseids"
+    "editor.url" : "http://www.perseids.org/tools/arethusa/app/#/perseids",
+    "workListUrl" : "http://sosol.perseids.org/exist/rest/db/xq/ctsworklist.xq?inv=annotsrc"
 }

--- a/app/static/css/alpheios/align.enter.css
+++ b/app/static/css/alpheios/align.enter.css
@@ -135,3 +135,21 @@ button[disabled] {
     font-style: italic;
     font-size: smaller;
 }
+
+.ownuri {
+    clear: both;
+}
+
+.button:hover {
+    border-style: outset;
+    border-color: #6a9fb5;
+    background-color:#90a959;
+    color: black;
+}
+
+.alt-version {
+  float: right;
+  font-size: smaller;
+  padding-right: 1em;
+}
+

--- a/app/static/css/alpheios/align.enter.css
+++ b/app/static/css/alpheios/align.enter.css
@@ -153,3 +153,8 @@ button[disabled] {
   padding-right: 1em;
 }
 
+
+.worklist {
+  clear: both;
+   font-size:smaller;
+}

--- a/app/static/css/alpheios/treebank.editor.css
+++ b/app/static/css/alpheios/treebank.editor.css
@@ -289,3 +289,4 @@ span.alph-tooltip {
 #alpheios-put-notice.error {
     color:red;
 }
+

--- a/app/static/css/arethusa.css
+++ b/app/static/css/arethusa.css
@@ -42,3 +42,12 @@ label.columns {
     font-size: 11px !important;
 
 }
+
+.worklist {
+  clear: both;
+  font-size:smaller;
+}
+
+.worklist a {
+  color: #4183C4;
+}

--- a/app/static/js/alpheios/align.enter.js
+++ b/app/static/js/alpheios/align.enter.js
@@ -29,8 +29,14 @@ var transform_done = { 'l1' : false, 'l2':false };
 $(document).ready(function() {
 
     // try to load text from the supplied uri
-    $("input[name='l1uri']").change(function() { load_text('l1'); });
-    $("input[name='l2uri']").change(function() { load_text('l2'); });
+    $("input[name='l1uri']").change(function() { load_text('l1',$(this).val()) });
+    $("input[name='l2uri']").change(function() { load_text('l2',$(this).val()) });
+    $(".own_uri_trigger").on("click", function(event) {
+        event.preventDefault();
+        var lnum = $(this).attr("data-lnum");
+        var textURI = $("#own_uri_" + lnum).val();
+        load_text(lnum,textURI);
+    });
 
     // get parameters from call
     var callParams = location.search.substr(1).split("&");
@@ -166,8 +172,10 @@ $(document).ready(function() {
 /**
  * Handler for the text_uri input to try to load the text
  */
-function load_text(lnum) {
-    var uri = $("input[name='" + lnum + "uri']").val();
+function load_text(lnum,uri) {
+    if (! uri)  {
+      uri = $("input[name='" + lnum + "uri']").val();
+    }
     if (! uri.match(/^http/)) {
        /** allow non-url identifiers to just pass through **/
         return;

--- a/app/static/js/alpheios/align.enter.js
+++ b/app/static/js/alpheios/align.enter.js
@@ -143,6 +143,22 @@ $(document).ready(function() {
 
 
     //Trigger queue
+    $("body").on("alpheios:ping-succeeded",function(event,data) {
+        put_data(data);
+    });
+
+    $("body").on("alpheios:ping-failed",function(event,data) {
+        alert("No session. Please login!");
+    });
+
+    $("body").on("alpheios:put-succeeded",function(event,data) {
+        submit_form(data);
+    });
+
+    $("body").on("alpheios:put-failed",function(event,data) {
+        alert(data);
+    });
+
     $(".advanced-options").on("cts-service:llt.tokenizer:done", function() {
         var lnum = $(this).attr("data-lnum");
         transform_done[lnum] = false;
@@ -266,19 +282,10 @@ function make_data() {
 
   $("language",l1).after(l2lang);
   $("wds",l1).after(l2wds);
-  put_data(l1);
+  AlphEdit.pingServer($("meta[name='pingurl']").attr("content"),l1);
 }
 
 function put_data(data) {
-    // a bit of a hack -- may need to ping the api get the cookie
-    // not actually needed at runtime when we come from there
-    // but was useful for testing
-    var pingUrl = $("meta[name='pingurl']").attr("content");
-    if (pingUrl) {
-        var req = new XMLHttpRequest();
-        req.open("GET", pingUrl, false);
-        req.send(null);
-    }
 
     // get the url for the post
     var url = $("meta[name='url']", document).attr("content");
@@ -288,22 +295,23 @@ function put_data(data) {
         // so that I can reuse the AlphEdit.putContents code
         AlphEdit.pushHistory(["create"],null);
         // send synchronous request to add
-        resp = AlphEdit.putContents(data, url, '' , '');
+        AlphEdit.putContents(data, url, '' , '');
     } catch (a_e) {
         alert(a_e);
-        return false;
     }
+    return false;
+}
 
+function submit_form(data) {
     // save values from return in submit form
     var form = $("form[name='submit-form']", document);
     var lang = $("#lang-buttons input[name='lang']:checked").val();
     var dir = $("#dir-buttons input[name='direction']:checked").val();
     $("input[name='inputtext']",form).attr("dir",dir);
 
-    var doc = $(resp).text();
+    var doc = $(data).text();
     var url = $("meta[name='editorurl']").attr("content").replace('REPLACE_DOC',doc);
     window.location.assign(url);
-    return false;
 }
 
 /**

--- a/app/static/js/alpheios/align.enter.js
+++ b/app/static/js/alpheios/align.enter.js
@@ -114,9 +114,7 @@ $(document).ready(function() {
             "e_appuri" : "input[name='appuri']",
             "e_title" : "input[name='docname']",
             "e_collection" :  "input[name='collection']",
-            "e_includepunc" : function() {
-              return $("input#" + lnum + "includepunc").is(":checked");
-            }
+            "e_includepunc": function() { return true; }
         },
         "trigger" : "llt-transform",
         "callback" : function(data) {

--- a/app/static/js/alpheios/edit.utils.js
+++ b/app/static/js/alpheios/edit.utils.js
@@ -385,22 +385,7 @@ putContents: function(a_xml, a_url, a_doc, a_sentid)
         "success": function(data,httpmsg,xhr) {
           if (data == null || $("error",data).length > 0) {
             var msg = "ERROR!! CHANGES NOT SAVED!<br/>"; 
-            // prefer explicit error messags over general http ones
-            if (data != null && $("error",data).length > 0) {  
-                var links = [];
-                $("link",data).each(function(){
-                    links.push($(this).attr("href") || $(this).attr("xlink:href"));
-                });
-                msg = msg + $(data).text();
-                for (var i=0; i<links.length; i++) {
-                    var regex = new RegExp(links[i].replace(/([.*+?^${}()|\[\]\/\\])/g, "\\$1"));
-                    msg = msg.replace(regex,'<a href="' + links[i] + '">' + links[i] + '</a>')
-                }
-            } else if (httpmsg) {
-                msg = msg + httpmsg;
-            } else {
-                msg = msg + "Error saving sentence " + a_sentid + " in " + a_doc;
-            }
+            msg = msg + httpmsg;
             $("#alpheios-put-notice").addClass("error").html(msg);
             $("body").trigger("alpheios:put-failed",[msg]);
           } else {
@@ -410,8 +395,20 @@ putContents: function(a_xml, a_url, a_doc, a_sentid)
         },
         error: function(xhr,msg,error) {
             msg = "ERROR!! CHANGES NOT SAVED!<br/>" + msg;
+            // prefer explicit error messags over general http ones
+            if ($("error",xhr.responseXML.documentElement)) {  
+                var links = [];
+                $("link",xhr.responseXML.documentElement).each(function(){
+                    links.push($(this).attr("href") || $(this).attr("xlink:href"));
+                });
+                msg = msg + $(xhr.responseXML.documentElement).text();
+                for (var i=0; i<links.length; i++) {
+                    var regex = new RegExp(links[i].replace(/([.*+?^${}()|\[\]\/\\])/g, "\\$1"));
+                    msg = msg.replace(regex,'<a href="' + links[i] + '">' + links[i] + '</a>')
+                }
+            }
             $("body").trigger("alpheios:put-failed",[msg]);
-        }
+       }
     });
 },
 

--- a/app/static/js/alpheios/treebank.enter.js
+++ b/app/static/js/alpheios/treebank.enter.js
@@ -159,6 +159,10 @@ $(document).ready(function() {
         submit_form(data);
     });
 
+    $("body").on("alpheios:put-failed",function(event,data) {
+        $("#alpheios-put-notice").addClass("error").html(data);
+    });
+
     $("#advanced-options").on("cts-service:llt.tokenizer:done", function() {
         $("#advanced-options").trigger("llt-transform");
     });

--- a/app/static/js/alpheios/treebank.enter.js
+++ b/app/static/js/alpheios/treebank.enter.js
@@ -131,7 +131,7 @@ $(document).ready(function() {
         "trigger" : "llt-transform",
         "callback" : function(data) {
             $("#inputtext").val(data);
-            return put_treebank(data);
+            return AlphEdit.pingServer($("meta[name='pingurl']").attr("content"),data);
         },
         "css" : {
             "field-container" : ["row"],
@@ -144,6 +144,18 @@ $(document).ready(function() {
     $("#advanced-options-toggle").click(function(){$("#advanced-options").toggle();});
 
     //Trigger queue
+    $("body").on("alpheios:ping-succeeded",function(event,data) {
+        put_treebank(data);
+    });
+
+    $("body").on("alpheios:ping-failed",function(event,data) {
+        alert("No session. Please login!");
+    });
+
+    $("body").on("alpheios:put-succeeded",function(event,data) {
+        submit_form(data);
+    });
+
     $("#advanced-options").on("cts-service:llt.tokenizer:done", function() {
         $("#advanced-options").trigger("llt-transform");
     });
@@ -266,15 +278,6 @@ function EnterSentence(a_event)
  *  @param  treebank  {string}  The treebank to be saved
  */
 function put_treebank(treebank) {
-    // a bit of a hack -- may need to ping the api get the cookie
-    // not actually needed at runtime when we come from there
-    // but was useful for testing
-    var pingUrl = $("meta[name='pingurl']").attr("content");
-    if (pingUrl) {
-        var req = new XMLHttpRequest();
-        req.open("GET", pingUrl, false);
-        req.send(null);
-    }
 
     // get the url for the post
     var url = $("meta[name='url']", document).attr("content");
@@ -295,7 +298,9 @@ function put_treebank(treebank) {
         alert(a_e);
         return false;
     }
+}
 
+function submit_form(data) {
     // save values from return in submit form
     var form = $("form[name='input-form']", document);
     var lang = $("input[name='lang']:checked").val();
@@ -307,11 +312,11 @@ function put_treebank(treebank) {
     // this is holdover from the old version of the code
     // in which the alpheios xquery code returned an element with
     // these parameters.
-    if ($(resp).attr("doc")) {
-        doc = $(resp).attr("doc");
-        s = $(resp).attr("s");
+    if ($(data).attr("doc")) {
+        doc = $(data).attr("doc");
+        s = $(data).attr("s");
     } else {
-        doc = $(resp).text();
+        doc = $(data).text();
     }
     // hack to work around form submission to hashbang urls
     var form_action = $("form[name='input-form']", document).attr("action"); 
@@ -390,9 +395,7 @@ function fileLoaded(data) {
         return false;
     }
     $("#file_upload").removeClass("loading");
-    if (put_treebank(annotation)) {
-        $("form[name='submit-form']", document).submit();
-    }
+    AlphEdit.pingServer($("meta[name='pingurl']").attr("content"),data);
 }
 
 /**

--- a/app/static/js/alpheios/treebank.enter.js
+++ b/app/static/js/alpheios/treebank.enter.js
@@ -209,8 +209,13 @@ function find_collection(a_lang) {
     'ara' : 'urn:cite:perseus:aratb',
     'misc' : 'urn:cite:perseus:misctb'
   };
-  // any other languages fall into misc collection for now
-  return collections[a_lang];
+  // use form override if any
+  var form_override = $("input[name='collection']");
+  if (form_override.length > 0 && form_override.val()) {
+    return form_override.val();
+  } else {
+    return collections[a_lang];
+  }
 }
 
 /**

--- a/app/static/js/alpheios/treebank.enter.js
+++ b/app/static/js/alpheios/treebank.enter.js
@@ -104,6 +104,9 @@ $(document).ready(function() {
             "field-label" : ["columns", "large-6", "small-6"],
             "field-input-container" : ["columns", "large-6", "small-6"]
         },
+        "defaults": {
+          "splitting": $("meta[name='isthematic']").length == 0
+        },
         "names" : {
             "xml" : "xml_for_llt"
         }

--- a/app/static/xslt/segtok_to_align.xsl
+++ b/app/static/xslt/segtok_to_align.xsl
@@ -150,12 +150,13 @@
     </xsl:template>
     
     <xsl:template match="tei:pc|pc">
-        <xsl:if test="$e_includepunc">
+        <!-- service isn't passing this properly right now so always include for now -->
+        <!--xsl:if test="$e_includepunc and $e_includepunc != '' and $e_includepunc != false() and $e_includepunc != 'false'">
+        </xsl:if-->
             <xsl:element name="w" namespace="http://alpheios.net/namespaces/aligned-text">
                 <xsl:attribute name="n"><xsl:value-of select="concat(@s_n,'-',@n)"/></xsl:attribute>
                 <xsl:element name="text" namespace="http://alpheios.net/namespaces/aligned-text"><xsl:value-of select="."/></xsl:element>
             </xsl:element>
-        </xsl:if>
     </xsl:template>
     
     <xsl:template match="@*"/>

--- a/app/templates/alignment/enter.html
+++ b/app/templates/alignment/enter.html
@@ -104,6 +104,7 @@
             <div>
               <label for="l1uri">{{ _('Search for a text:') }}</label>
               <input placeholder="{{ _('URI Identifer for this text. If a URL, text will be loaded from there. Plain text only supported.') }}" type="url" id="l1uri" name="l1uri" size="100" class="texturi" data-lnum="l1"></input>
+              <div id="l1worklist" class="worklist"><a target="_blank" href="{{alignment('workListUrl')}}">Available Works</a></div>
             </div>
             <div class="ownuri">
               <label for="own_uri_l1">{{ _('Or enter your own text URI:') }}</label>
@@ -134,6 +135,7 @@
           <div>
             <label for="l2uri">{{ _('Search for a text:') }}</label>
             <input placeholder="{{ _('URI Identifer for this text. If a URL, text will be loaded from there. Plain text only supported.') }}" type="url" id="l2uri" name="l2uri" size="100" class="texturi" data-lnum="l2"></input>
+            <div id="l2worklist" class="worklist"><a target="_blank" href="{{alignment('workListUrl')}}">Available Works</a></div>
           </div>
           <div class="ownuri">
             <label for="own_uri_l2">{{ _('Or enter your own text URI:') }}</label>

--- a/app/templates/alignment/enter.html
+++ b/app/templates/alignment/enter.html
@@ -68,6 +68,10 @@
         <img src="static/img/alpheios/alpheios-transparent.png" alt="Alpheios"/>
       </div>
     </div>
+    <div class="alt-version">
+       <a href="{{ alignment('altVersionUrl') }}">{{ _('Switch to prior version of this form') }}</a>
+    </div>
+
     <div>
       <form name="input-form" action="">
         <input type="hidden" name="l1"/>
@@ -98,9 +102,21 @@
            </div>
            <div class="textdriver" id="l1textdriver" data-lnum="l1"></div>
             <div>
-              <label for="l1uri">{{ _('Text URI') }}</label>
-              <input placeholder="{{ ('URI Identifer for this text. If a URL, text will be loaded from there. Plain text only supported.') }}" type="url" id="l1uri" name="l1uri" size="100" class="texturi" data-lnum="l1"></input>
+              <label for="l1uri">{{ _('Search for a text:') }}</label>
+              <input placeholder="{{ _('URI Identifer for this text. If a URL, text will be loaded from there. Plain text only supported.') }}" type="url" id="l1uri" name="l1uri" size="100" class="texturi" data-lnum="l1"></input>
             </div>
+            <div class="ownuri">
+              <label for="own_uri_l1">{{ _('Or enter your own text URI:') }}</label>
+              <div class="row collapse">
+                <div class="small-10 columns">
+                  <input type="text" placeholder="" id="own_uri_l1" />
+                </div>
+                <div class="small-2 columns">
+                  <a href="#" data-lnum="l1" class="own_uri_trigger button postfix">{{ _('Select') }}</a>
+                </div>
+              </div>
+              <small class="error" id="own_uri_l1_error" style="display:none;">{{ _('Invalid entry') }}</small>
+           </div>
           </fieldset>
           <fieldset class="large-6 columns">
           <legend>{{ _('Enter Text in Language 2:') }}</legend>
@@ -116,9 +132,21 @@
           <small class="error" id="l2texterror" style="display:none;">{{ _('Invalid entry') }}</small>
           <div class="textdriver" id="l2textdriver" data-lnum="l2"></div>
           <div>
-            <label for="l2uri">{{ _('Text URI') }}</label>
-            <input placeholder="{{ ('URI Identifer for this text. If a URL, text will be loaded from there. Plain text only supported.') }}" type="url" id="l2uri" name="l2uri" size="100" class="texturi" data-lnum="l2"></input>
+            <label for="l2uri">{{ _('Search for a text:') }}</label>
+            <input placeholder="{{ _('URI Identifer for this text. If a URL, text will be loaded from there. Plain text only supported.') }}" type="url" id="l2uri" name="l2uri" size="100" class="texturi" data-lnum="l2"></input>
           </div>
+          <div class="ownuri">
+            <label for="own_uri_l2">{{ _('Or enter your own text URI:') }}</label>
+            <div class="row collapse">
+              <div class="small-10 columns">
+                <input type="text" placeholder="" id="own_uri_l2" />
+              </div>
+              <div class="small-2 columns">
+                <a href="#" data-lnum="l2" class="own_uri_trigger button postfix">{{ _('Select') }}</a>
+              </div>
+            </div>
+            <small class="error" id="own_uri_l2_error" style="display:none;">{{ _('Invalid entry') }}</small>
+         </div>
         </fieldset>
         </div>
         <div class="row">
@@ -270,7 +298,7 @@
           <fieldset class="large-6 columns">
             <div class="row">
               <label for="select_l2" class="large-9 columns">{{ _('Language 2:') }}
-            <select name="select_l2" id="select_l1">
+            <select name="select_l2" id="select_l2">
               <option value="eng">{{ _('English') }}</option>
               <option value="lat">{{ _('Latin') }}</option>
               <option value="grc">{{ _('Greek (Ancient -1453)') }}</option>

--- a/app/templates/treebank/enter.html
+++ b/app/templates/treebank/enter.html
@@ -66,6 +66,7 @@
                         </div>
                         <label for="text_uri">{{ _('Search for a text') }}</label>
                         <input type="text" id="text_uri" name="text_uri" size="100"/>
+                        <div id="worklist" class="worklist"><a target="_blank" href="{{treebank('workListUrl')}}">Available Works</a></div>
                         <br />
                         <div class="row">
                             <div class="large-12 columns">

--- a/app/templates/treebank/theme.html
+++ b/app/templates/treebank/theme.html
@@ -68,6 +68,7 @@
                         </div>
                         <label for="text_uri">{{ _('Search for a text') }}</label>
                         <input type="text" id="text_uri" name="text_uri" size="100"/>
+                        <div id="worklist" class="worklist"><a target="_blank" href="{{treebank('workListUrl')}}">Available Works</a></div>
                         <br />
                         <div class="row">
                             <div class="large-12 columns">

--- a/app/templates/treebank/theme.html
+++ b/app/templates/treebank/theme.html
@@ -120,6 +120,7 @@
                                 </div>
                             </fieldset>
                         </div>
+                        <div id="alpheios-put-notice"></div>
                     </div>
                 </div>
             </form>

--- a/app/templates/treebank/theme.html
+++ b/app/templates/treebank/theme.html
@@ -58,6 +58,7 @@
         </header>
         <div>
             <form name="input-form" action="{{ treebank('editor.url') }}" onsubmit="return EnterSentence(event);" method="GET">
+                <input type="hidden" name="collection" value="urn:cite:perseus:vortextb"/>
                 <div class="row">
                     <fieldset class="large-6 columns">
                         <legend for="inputtext">{{ _('Input text:') }}</legend>

--- a/app/templates/treebank/theme.html
+++ b/app/templates/treebank/theme.html
@@ -1,0 +1,128 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <head>
+        <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/foundation/5.5.0/css/foundation.min.css" />
+        <link rel="stylesheet" type="text/css" href="static/css/alpheios/treebank.list.css"/>
+        <link rel="stylesheet" type="text/css" href="static/css/arethusa.css"/>
+        <link rel="stylesheet" type="text/css" href="{{ bower_url_for('capitains-sparrow.typeahead', 'src/css/jquery.cts.typeahead.css') }}" />
+
+        <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+
+        <script src="{{ bower_url_for('handlebars', 'handlebars.min.js') }}"></script>
+        <script src="{{ bower_url_for('typeahead.js', 'dist/typeahead.bundle.min.js') }}"></script>
+
+        <script src="{{ bower_url_for('capitains-sparrow', 'dist/cts.min.js') }}"></script>
+        <script src="{{ bower_url_for('capitains-sparrow.typeahead', 'dist/jquery.cts.typeahead.min.js') }}"></script>
+        <script src="{{ bower_url_for('capitains-sparrow.xslt', 'dist/jquery.cts.xslt.min.js') }}"></script>
+        <script src="{{ bower_url_for('capitains-sparrow.service', 'dist/jquery.cts.service.min.js') }}"></script>
+
+        <script type="text/javascript" src="static/js/alpheios/treebank.enter.js"></script>
+        <script type="text/javascript" src="static/js/alpheios/edit.utils.js"></script>
+
+    <!-- cookie and header name for CSRF session token  -->
+        <meta name="alpheios-sessionTokenName" content="{{ session('sessionTokenName') }}"/>
+        <meta name="alpheios-sessionHeaderName" content="{{ session('sessionHeaderName') }}"/>
+        <meta name="isthematic" content="true"/>
+    
+    <!-- url to ping the server to set/refresh the CSRF cookie -->
+        <meta name="pingurl" content="{{ session('pingUrl') }}" />
+    
+    <!-- url to POST to to create store a new treebank template -->
+        <meta name="url" content="{{ treebank('endpoint.create') }}" />
+    <!-- url to redirect to create new treebank template from an existing -->
+        <meta name="linkurl" content="{{ treebank('endpoint.create.linked_urn') }}"/>
+    
+    <!-- default url to the tokenization service to use to process the input text. 
+         can be overridden per language.
+         - @content contains the base url for the tokenizatoin service POST 
+         - @data-params contains the names of input elements from the form which should
+           be forwarded to the tokenization service.  The format of this is a space separated list of 
+           attribute names. the attribute names optionally can be | separated map from the name of this 
+           parameter in the input form to the name of the parameter on the tokenization service.
+           this is a complete hack but was a quick and dirty way to reuse the existing form
+         - @data-transform contains the path to the XSLT transformation to apply to the tokenization
+           service output to create the treebank template for posting to to the back end storage service
+    -->
+        <meta name="tokenization_service" content="{{ treebank('tokenization.endpoint') }}" data-params="{{ treebank('tokenization.params') }}" data-transform="{{ treebank('tokenization.xslt') }}"/>
+    
+    <!-- path to a transformation which wraps a treebank file in OA -->
+        <meta name="oa_wrapper_transform" content="{{ treebank('oa.xslt') }}"/>
+
+        <meta name="cts_repos_url" content="{{ cts('endpoint') }}" />
+        <meta name="cts_capabilities_url" content="{{ cts('getCapabilities') }}"/>
+    </head>
+    <body>
+        <header class="alpheios-ignore">
+            <div id="alph-page-header">
+                <img src="http://www.perseids.org/tools/arethusa/app/images/arethusa.png" alt="Arethusa"/>
+            </div>
+        </header>
+        <div>
+            <form name="input-form" action="{{ treebank('editor.url') }}" onsubmit="return EnterSentence(event);" method="GET">
+                <div class="row">
+                    <fieldset class="large-6 columns">
+                        <legend for="inputtext">{{ _('Input text:') }}</legend>
+                        <div>
+                            <textarea id="inputtext" name="inputtext" rows="10" cols="80" placeholder="{{ _('Enter the text you want to annotate...') }} "></textarea>
+                            <small class="error" id="texterror" style="display:none;">{{ _('Invalid entry') }}</small>
+                        </div>
+                        <label for="text_uri">{{ _('Search for a text') }}</label>
+                        <input type="text" id="text_uri" name="text_uri" size="100"/>
+                        <br />
+                        <div class="row">
+                            <div class="large-12 columns">
+                              <label for="own_uri">{{ _('Enter your own text URI :') }} </label>
+                              <div class="row collapse">
+                                <div class="small-10 columns">
+                                  <input type="text" placeholder="" id="own_uri" />
+                                </div>
+                                <div class="small-2 columns">
+                                  <a href="#" id="own_uri_trigger" class="button postfix">{{ _('Select') }}</a>
+                                </div>
+                              </div>
+                              <small class="error" id="own_uri_error" style="display:none;">{{ _('Invalid entry') }}</small>
+                            </div>
+                        </div>
+                    </fieldset>
+                    <div class="large-6 columns">
+                        <fieldset id="lang-buttons">
+                            <legend>{{ _('Language:') }}</legend>
+                            <input type="radio" id="lang-grc" name="lang" value="grc"/>
+                            <label for="lang-grc">{{ _('Greek') }}</label>
+                            <input type="radio" id="lang-lat" name="lang" value="lat" />
+                            <label for="lang-lat">{{ _('Latin') }}</label>
+                            <input type="radio" id="lang-ara" name="lang" value="ara"/>
+                            <label for="lang-ara">{{ _('Arabic') }}</label>
+                        </fieldset>
+                        <fieldset id="dir-buttons">
+                            <legend>{{ _('Text Direction:') }}</legend>
+                            <input type="radio" id="dir-ltr" name="direction" value="ltr" checked="checked"/>
+                            <label for="dir-ltr">{{ _('Left to Right') }}</label>
+                            <input type="radio" id="dir-rtl" name="direction" value="rtl"/>
+                            <label for="dir-rtl">{{ _('Right to Left') }}</label>
+                        </fieldset>
+                        <div>
+                            <input type="hidden" name="doc"/>
+                            <input type="hidden" name="s"/>
+                            <input type="hidden" name="direction" value="ltr"/>
+                            <input type="hidden" name="lang" value=""/>
+                            <input type="hidden" id="appuri" name="appuri" value="http://github.com/latin-language-toolkit/arethusa"/>
+                            <button type="submit" class="button small">{{ _('Edit') }}</button>
+                        </div>
+                        <small id="advanced-options-toggle" class="toggle_hint">{{ _('Click  to toggle advanced options...') }}</small>
+                        <div id="advanced-options" style="display: none;">
+                            <fieldset id="format-buttons">
+                                <legend>Format:</legend>
+                                <div class="row">
+                                    <label class="columns large-8 small-8" for="format-vortex">{{ _('Vortex') }}</label>
+                                    <div class="columns large-4 small-4">
+                                        <input type="radio" id="format-vortex" name="format" value="vortex" checked="checked"/>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </body>
+</html>

--- a/app/translations/en/LC_MESSAGES/messages.po
+++ b/app/translations/en/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Alpheios Flask App\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-03-27 13:25+0000\n"
+"POT-Creation-Date: 2015-04-13 18:10+0000\n"
 "PO-Revision-Date: 2015-03-27 09:37-0500\n"
 "Last-Translator: Bridget Almas <balmas@gmail.com>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -18,734 +18,758 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 1.3\n"
 
-#: app/templates/alignment/enter.html:77
+#: app/templates/alignment/enter.html:72
+msgid "Switch to prior version of this form"
+msgstr ""
+
+#: app/templates/alignment/enter.html:82
 msgid "Enter Metadata:"
 msgstr "Enter Metadata:"
 
-#: app/templates/alignment/enter.html:78
+#: app/templates/alignment/enter.html:83
 msgid "Alignment title:"
 msgstr "Alignment title:"
 
-#: app/templates/alignment/enter.html:78
+#: app/templates/alignment/enter.html:83
 msgid "alignmenttitlehint"
-msgstr "e.g. \"Alignment of Thuc. 1.1 in French and English\" (100 chars max restricted to alphanumerics and '.','_' and '-')"
+msgstr ""
+"e.g. \"Alignment of Thuc. 1.1 in French and English\" (100 chars max "
+"restricted to alphanumerics and '.','_' and '-')"
 
-#: app/templates/alignment/enter.html:79
+#: app/templates/alignment/enter.html:84
 msgid "Enter a short title for your annotation"
 msgstr "Enter a short title for your annotation"
 
-#: app/templates/alignment/enter.html:85
+#: app/templates/alignment/enter.html:90
 msgid "Enter Text in Language 1:"
 msgstr "Enter Text in Language 1:"
 
-#: app/templates/alignment/enter.html:87
-#: app/templates/alignment/enter.html:107
+#: app/templates/alignment/enter.html:92 app/templates/alignment/enter.html:124
 #: app/templates/treebank/enter.html:98
 msgid "Text Direction:"
 msgstr "Text Direction:"
 
-#: app/templates/alignment/enter.html:89
-#: app/templates/alignment/enter.html:109
+#: app/templates/alignment/enter.html:94 app/templates/alignment/enter.html:126
 #: app/templates/treebank/enter.html:100
 msgid "Left to Right"
 msgstr "Left to Right"
 
-#: app/templates/alignment/enter.html:91
-#: app/templates/alignment/enter.html:111
+#: app/templates/alignment/enter.html:96 app/templates/alignment/enter.html:128
 #: app/templates/treebank/enter.html:102
 msgid "Right to Left"
 msgstr "Right to Left"
 
-#: app/templates/alignment/enter.html:96
-#: app/templates/alignment/enter.html:115
-#: app/templates/treebank/enter.html:65
+#: app/templates/alignment/enter.html:101
+#: app/templates/alignment/enter.html:118
+#: app/templates/alignment/enter.html:132
+#: app/templates/alignment/enter.html:148 app/templates/treebank/enter.html:65
 #: app/templates/treebank/enter.html:81
 msgid "Invalid entry"
 msgstr "Invalid entry"
 
-#: app/templates/alignment/enter.html:100
-#: app/templates/alignment/enter.html:118
-msgid "Text URI"
-msgstr "Text URI"
-
 #: app/templates/alignment/enter.html:105
+#: app/templates/alignment/enter.html:135
+#, fuzzy
+msgid "Search for a text:"
+msgstr "Search for a text"
+
+#: app/templates/alignment/enter.html:106
+#: app/templates/alignment/enter.html:136
+msgid ""
+"URI Identifer for this text. If a URL, text will be loaded from there. "
+"Plain text only supported."
+msgstr ""
+
+#: app/templates/alignment/enter.html:109
+#: app/templates/alignment/enter.html:139
+#, fuzzy
+msgid "Or enter your own text URI:"
+msgstr "Enter your own text URI :"
+
+#: app/templates/alignment/enter.html:115
+#: app/templates/alignment/enter.html:145 app/templates/treebank/enter.html:78
+msgid "Select"
+msgstr "Select"
+
+#: app/templates/alignment/enter.html:122
 msgid "Enter Text in Language 2:"
 msgstr "Enter Text in Language 2:"
 
-#: app/templates/alignment/enter.html:126
+#: app/templates/alignment/enter.html:155
 msgid "Language 1:"
 msgstr "Language 1:"
 
-#: app/templates/alignment/enter.html:128
-#: app/templates/alignment/enter.html:273
+#: app/templates/alignment/enter.html:157
+#: app/templates/alignment/enter.html:302
 msgid "English"
 msgstr "English"
 
-#: app/templates/alignment/enter.html:129
-#: app/templates/alignment/enter.html:274
-#: app/templates/treebank/enter.html:91
+#: app/templates/alignment/enter.html:158
+#: app/templates/alignment/enter.html:303 app/templates/treebank/enter.html:91
 msgid "Latin"
 msgstr "Latin"
 
-#: app/templates/alignment/enter.html:130
-#: app/templates/alignment/enter.html:275
+#: app/templates/alignment/enter.html:159
+#: app/templates/alignment/enter.html:304
 msgid "Greek (Ancient -1453)"
 msgstr "Greek (Ancient -1453)"
 
-#: app/templates/alignment/enter.html:131
-#: app/templates/alignment/enter.html:276
-#: app/templates/treebank/enter.html:93
+#: app/templates/alignment/enter.html:160
+#: app/templates/alignment/enter.html:305 app/templates/treebank/enter.html:93
 msgid "Arabic"
 msgstr "Arabic"
 
-#: app/templates/alignment/enter.html:132
-#: app/templates/alignment/enter.html:277
+#: app/templates/alignment/enter.html:161
+#: app/templates/alignment/enter.html:306
 msgid "Chinese"
 msgstr "Chinese"
 
-#: app/templates/alignment/enter.html:133
-#: app/templates/alignment/enter.html:278
+#: app/templates/alignment/enter.html:162
+#: app/templates/alignment/enter.html:307
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
-#: app/templates/alignment/enter.html:134
-#: app/templates/alignment/enter.html:279
+#: app/templates/alignment/enter.html:163
+#: app/templates/alignment/enter.html:308
 msgid "Akkadian"
 msgstr "Akkadian"
 
-#: app/templates/alignment/enter.html:135
-#: app/templates/alignment/enter.html:280
+#: app/templates/alignment/enter.html:164
+#: app/templates/alignment/enter.html:309
 msgid "Albanian"
 msgstr "Albanian"
 
-#: app/templates/alignment/enter.html:136
-#: app/templates/alignment/enter.html:281
+#: app/templates/alignment/enter.html:165
+#: app/templates/alignment/enter.html:310
 msgid "Amharic"
 msgstr "Amharic"
 
-#: app/templates/alignment/enter.html:137
-#: app/templates/alignment/enter.html:282
+#: app/templates/alignment/enter.html:166
+#: app/templates/alignment/enter.html:311
 msgid "Aragonese"
 msgstr "Aragonese"
 
-#: app/templates/alignment/enter.html:138
-#: app/templates/alignment/enter.html:283
+#: app/templates/alignment/enter.html:167
+#: app/templates/alignment/enter.html:312
 msgid "Aramaic (Imperial- 700 BC-300 BC)"
 msgstr "Aramaic (Imperial- 700 BC-300 BC)"
 
-#: app/templates/alignment/enter.html:139
-#: app/templates/alignment/enter.html:284
+#: app/templates/alignment/enter.html:168
+#: app/templates/alignment/enter.html:313
 msgid "Aramaic (Samaritan)"
 msgstr "Aramaic (Samaritan)"
 
-#: app/templates/alignment/enter.html:140
-#: app/templates/alignment/enter.html:285
+#: app/templates/alignment/enter.html:169
+#: app/templates/alignment/enter.html:314
 msgid "Armenian"
 msgstr "Armenian"
 
-#: app/templates/alignment/enter.html:141
-#: app/templates/alignment/enter.html:286
+#: app/templates/alignment/enter.html:170
+#: app/templates/alignment/enter.html:315
 msgid "Asturian (Bable, Leonese)"
 msgstr "Asturian (Bable, Leonese)"
 
-#: app/templates/alignment/enter.html:142
-#: app/templates/alignment/enter.html:287
+#: app/templates/alignment/enter.html:171
+#: app/templates/alignment/enter.html:316
 msgid "Avestan"
 msgstr "Avestan"
 
-#: app/templates/alignment/enter.html:143
-#: app/templates/alignment/enter.html:288
+#: app/templates/alignment/enter.html:172
+#: app/templates/alignment/enter.html:317
 msgid "Azerbaijani"
 msgstr "Azerbaijani"
 
-#: app/templates/alignment/enter.html:144
-#: app/templates/alignment/enter.html:289
+#: app/templates/alignment/enter.html:173
+#: app/templates/alignment/enter.html:318
 msgid "Basque"
 msgstr "Basque"
 
-#: app/templates/alignment/enter.html:145
-#: app/templates/alignment/enter.html:290
+#: app/templates/alignment/enter.html:174
+#: app/templates/alignment/enter.html:319
 msgid "Bengali"
 msgstr "Bengali"
 
-#: app/templates/alignment/enter.html:146
-#: app/templates/alignment/enter.html:291
+#: app/templates/alignment/enter.html:175
+#: app/templates/alignment/enter.html:320
 msgid "Berber"
 msgstr "Berber"
 
-#: app/templates/alignment/enter.html:147
-#: app/templates/alignment/enter.html:292
+#: app/templates/alignment/enter.html:176
+#: app/templates/alignment/enter.html:321
 msgid "Bosnian"
 msgstr "Bosnian"
 
-#: app/templates/alignment/enter.html:148
-#: app/templates/alignment/enter.html:293
+#: app/templates/alignment/enter.html:177
+#: app/templates/alignment/enter.html:322
 msgid "Breton"
 msgstr "Breton"
 
-#: app/templates/alignment/enter.html:149
-#: app/templates/alignment/enter.html:294
+#: app/templates/alignment/enter.html:178
+#: app/templates/alignment/enter.html:323
 msgid "Bulgarian"
 msgstr "Bulgarian"
 
-#: app/templates/alignment/enter.html:150
-#: app/templates/alignment/enter.html:295
+#: app/templates/alignment/enter.html:179
+#: app/templates/alignment/enter.html:324
 msgid "Bulgarian (Old, Old Church Slavonic)"
 msgstr "Bulgarian (Old, Old Church Slavonic)"
 
-#: app/templates/alignment/enter.html:151
-#: app/templates/alignment/enter.html:296
+#: app/templates/alignment/enter.html:180
+#: app/templates/alignment/enter.html:325
 msgid "Burmese"
 msgstr "Burmese"
 
-#: app/templates/alignment/enter.html:152
-#: app/templates/alignment/enter.html:297
+#: app/templates/alignment/enter.html:181
+#: app/templates/alignment/enter.html:326
 msgid "Catalan"
 msgstr "Catalan"
 
-#: app/templates/alignment/enter.html:153
-#: app/templates/alignment/enter.html:298
+#: app/templates/alignment/enter.html:182
+#: app/templates/alignment/enter.html:327
 msgid "Chagatai"
 msgstr "Chagatai"
 
-#: app/templates/alignment/enter.html:154
-#: app/templates/alignment/enter.html:299
+#: app/templates/alignment/enter.html:183
+#: app/templates/alignment/enter.html:328
 msgid "Coptic"
 msgstr "Coptic"
 
-#: app/templates/alignment/enter.html:155
-#: app/templates/alignment/enter.html:300
+#: app/templates/alignment/enter.html:184
+#: app/templates/alignment/enter.html:329
 msgid "Cornish"
 msgstr "Cornish"
 
-#: app/templates/alignment/enter.html:156
-#: app/templates/alignment/enter.html:301
+#: app/templates/alignment/enter.html:185
+#: app/templates/alignment/enter.html:330
 msgid "Croatian"
 msgstr "Croatian"
 
-#: app/templates/alignment/enter.html:157
-#: app/templates/alignment/enter.html:302
+#: app/templates/alignment/enter.html:186
+#: app/templates/alignment/enter.html:331
 msgid "Czech"
 msgstr "Czech"
 
-#: app/templates/alignment/enter.html:158
-#: app/templates/alignment/enter.html:303
+#: app/templates/alignment/enter.html:187
+#: app/templates/alignment/enter.html:332
 msgid "Danish"
 msgstr "Danish"
 
-#: app/templates/alignment/enter.html:159
-#: app/templates/alignment/enter.html:304
+#: app/templates/alignment/enter.html:188
+#: app/templates/alignment/enter.html:333
 msgid "Dutch (Flemish)"
 msgstr "Dutch (Flemish)"
 
-#: app/templates/alignment/enter.html:160
-#: app/templates/alignment/enter.html:305
+#: app/templates/alignment/enter.html:189
+#: app/templates/alignment/enter.html:334
 msgid "Dutch (Middle, 1050-1350)"
 msgstr "Dutch (Middle, 1050-1350)"
 
-#: app/templates/alignment/enter.html:161
-#: app/templates/alignment/enter.html:306
+#: app/templates/alignment/enter.html:190
+#: app/templates/alignment/enter.html:335
 msgid "Egyptian (Ancient)"
 msgstr "Egyptian (Ancient)"
 
-#: app/templates/alignment/enter.html:162
-#: app/templates/alignment/enter.html:307
+#: app/templates/alignment/enter.html:191
+#: app/templates/alignment/enter.html:336
 msgid "Elamite"
 msgstr "Elamite"
 
-#: app/templates/alignment/enter.html:163
-#: app/templates/alignment/enter.html:308
+#: app/templates/alignment/enter.html:192
+#: app/templates/alignment/enter.html:337
 msgid "English (Middle, 1100-1500)"
 msgstr "English (Middle, 1100-1500)"
 
-#: app/templates/alignment/enter.html:164
-#: app/templates/alignment/enter.html:309
+#: app/templates/alignment/enter.html:193
+#: app/templates/alignment/enter.html:338
 msgid "English (Old, 450-1100)"
 msgstr "English (Old, 450-1100)"
 
-#: app/templates/alignment/enter.html:165
-#: app/templates/alignment/enter.html:310
+#: app/templates/alignment/enter.html:194
+#: app/templates/alignment/enter.html:339
 msgid "Estonian"
 msgstr "Estonian"
 
-#: app/templates/alignment/enter.html:166
-#: app/templates/alignment/enter.html:311
+#: app/templates/alignment/enter.html:195
+#: app/templates/alignment/enter.html:340
 msgid "Finnish"
 msgstr "Finnish"
 
-#: app/templates/alignment/enter.html:167
-#: app/templates/alignment/enter.html:312
+#: app/templates/alignment/enter.html:196
+#: app/templates/alignment/enter.html:341
 msgid "French"
 msgstr "French"
 
-#: app/templates/alignment/enter.html:168
-#: app/templates/alignment/enter.html:313
+#: app/templates/alignment/enter.html:197
+#: app/templates/alignment/enter.html:342
 msgid "French (Middle, 1400-1600)"
 msgstr "French (Middle, 1400-1600)"
 
-#: app/templates/alignment/enter.html:169
+#: app/templates/alignment/enter.html:198
 msgid "French (Old, 842c. 1400)"
 msgstr "French (Old, 842c. 1400)"
 
-#: app/templates/alignment/enter.html:170
-#: app/templates/alignment/enter.html:315
+#: app/templates/alignment/enter.html:199
+#: app/templates/alignment/enter.html:344
 msgid "Ge'ez"
 msgstr "Ge'ez"
 
-#: app/templates/alignment/enter.html:171
-#: app/templates/alignment/enter.html:316
+#: app/templates/alignment/enter.html:200
+#: app/templates/alignment/enter.html:345
 msgid "Georgian"
 msgstr "Georgian"
 
-#: app/templates/alignment/enter.html:172
-#: app/templates/alignment/enter.html:317
+#: app/templates/alignment/enter.html:201
+#: app/templates/alignment/enter.html:346
 msgid "German (Low, Low Saxon)"
 msgstr "German (Low, Low Saxon)"
 
-#: app/templates/alignment/enter.html:173
-#: app/templates/alignment/enter.html:318
+#: app/templates/alignment/enter.html:202
+#: app/templates/alignment/enter.html:347
 msgid "German (Middle-High, 1050-1500)"
 msgstr "German (Middle-High, 1050-1500)"
 
-#: app/templates/alignment/enter.html:174
-#: app/templates/alignment/enter.html:319
+#: app/templates/alignment/enter.html:203
+#: app/templates/alignment/enter.html:348
 msgid "German (Old-High, 750-1050)"
 msgstr "German (Old-High, 750-1050)"
 
-#: app/templates/alignment/enter.html:175
-#: app/templates/alignment/enter.html:320
+#: app/templates/alignment/enter.html:204
+#: app/templates/alignment/enter.html:349
 msgid "German"
 msgstr "German"
 
-#: app/templates/alignment/enter.html:176
-#: app/templates/alignment/enter.html:321
+#: app/templates/alignment/enter.html:205
+#: app/templates/alignment/enter.html:350
 msgid "Gothic"
 msgstr "Gothic"
 
-#: app/templates/alignment/enter.html:177
-#: app/templates/alignment/enter.html:322
+#: app/templates/alignment/enter.html:206
+#: app/templates/alignment/enter.html:351
 msgid "Greek (Modern, 1453-)"
 msgstr "Greek (Modern, 1453-)"
 
-#: app/templates/alignment/enter.html:178
-#: app/templates/alignment/enter.html:323
+#: app/templates/alignment/enter.html:207
+#: app/templates/alignment/enter.html:352
 msgid "Gujarati"
 msgstr "Gujarati"
 
-#: app/templates/alignment/enter.html:179
-#: app/templates/alignment/enter.html:324
+#: app/templates/alignment/enter.html:208
+#: app/templates/alignment/enter.html:353
 msgid "Hebrew"
 msgstr "Hebrew"
 
-#: app/templates/alignment/enter.html:180
-#: app/templates/alignment/enter.html:325
+#: app/templates/alignment/enter.html:209
+#: app/templates/alignment/enter.html:354
 msgid "Hindi"
 msgstr "Hindi"
 
-#: app/templates/alignment/enter.html:181
-#: app/templates/alignment/enter.html:326
+#: app/templates/alignment/enter.html:210
+#: app/templates/alignment/enter.html:355
 msgid "Hittite"
 msgstr "Hittite"
 
-#: app/templates/alignment/enter.html:182
-#: app/templates/alignment/enter.html:327
+#: app/templates/alignment/enter.html:211
+#: app/templates/alignment/enter.html:356
 msgid "Hungarian"
 msgstr "Hungarian"
 
-#: app/templates/alignment/enter.html:183
-#: app/templates/alignment/enter.html:328
+#: app/templates/alignment/enter.html:212
+#: app/templates/alignment/enter.html:357
 msgid "Icelandic"
 msgstr "Icelandic"
 
-#: app/templates/alignment/enter.html:184
-#: app/templates/alignment/enter.html:329
+#: app/templates/alignment/enter.html:213
+#: app/templates/alignment/enter.html:358
 msgid "Indonesian"
 msgstr "Indonesian"
 
-#: app/templates/alignment/enter.html:185
-#: app/templates/alignment/enter.html:330
+#: app/templates/alignment/enter.html:214
+#: app/templates/alignment/enter.html:359
 msgid "Irish (Modern)"
 msgstr "Irish (Modern)"
 
-#: app/templates/alignment/enter.html:186
-#: app/templates/alignment/enter.html:331
+#: app/templates/alignment/enter.html:215
+#: app/templates/alignment/enter.html:360
 msgid "Irish (Middle 900-1200)"
 msgstr "Irish (Middle 900-1200)"
 
-#: app/templates/alignment/enter.html:187
-#: app/templates/alignment/enter.html:332
+#: app/templates/alignment/enter.html:216
+#: app/templates/alignment/enter.html:361
 msgid "Irish (Old, to 900)"
 msgstr "Irish (Old, to 900)"
 
-#: app/templates/alignment/enter.html:188
-#: app/templates/alignment/enter.html:333
+#: app/templates/alignment/enter.html:217
+#: app/templates/alignment/enter.html:362
 msgid "Italian"
 msgstr "Italian"
 
-#: app/templates/alignment/enter.html:189
-#: app/templates/alignment/enter.html:334
+#: app/templates/alignment/enter.html:218
+#: app/templates/alignment/enter.html:363
 msgid "Japanese"
 msgstr "Japanese"
 
-#: app/templates/alignment/enter.html:190
-#: app/templates/alignment/enter.html:335
+#: app/templates/alignment/enter.html:219
+#: app/templates/alignment/enter.html:364
 msgid "Javanese"
 msgstr "Javanese"
 
-#: app/templates/alignment/enter.html:191
-#: app/templates/alignment/enter.html:336
+#: app/templates/alignment/enter.html:220
+#: app/templates/alignment/enter.html:365
 msgid "Kannada"
 msgstr "Kannada"
 
-#: app/templates/alignment/enter.html:192
-#: app/templates/alignment/enter.html:337
+#: app/templates/alignment/enter.html:221
+#: app/templates/alignment/enter.html:366
 msgid "Khmer (Central)"
 msgstr "Khmer (Central)"
 
-#: app/templates/alignment/enter.html:193
-#: app/templates/alignment/enter.html:338
+#: app/templates/alignment/enter.html:222
+#: app/templates/alignment/enter.html:367
 msgid "Korean"
 msgstr "Korean"
 
-#: app/templates/alignment/enter.html:194
-#: app/templates/alignment/enter.html:339
+#: app/templates/alignment/enter.html:223
+#: app/templates/alignment/enter.html:368
 msgid "Kurdish"
 msgstr "Kurdish"
 
-#: app/templates/alignment/enter.html:195
-#: app/templates/alignment/enter.html:340
+#: app/templates/alignment/enter.html:224
+#: app/templates/alignment/enter.html:369
 msgid "Ladino"
 msgstr "Ladino"
 
-#: app/templates/alignment/enter.html:196
-#: app/templates/alignment/enter.html:341
+#: app/templates/alignment/enter.html:225
+#: app/templates/alignment/enter.html:370
 msgid "Lithuanian"
 msgstr "Lithuanian"
 
-#: app/templates/alignment/enter.html:197
-#: app/templates/alignment/enter.html:342
+#: app/templates/alignment/enter.html:226
+#: app/templates/alignment/enter.html:371
 msgid "Malay"
 msgstr "Malay"
 
-#: app/templates/alignment/enter.html:198
-#: app/templates/alignment/enter.html:343
+#: app/templates/alignment/enter.html:227
+#: app/templates/alignment/enter.html:372
 msgid "Marathi"
 msgstr "Marathi"
 
-#: app/templates/alignment/enter.html:199
-#: app/templates/alignment/enter.html:344
+#: app/templates/alignment/enter.html:228
+#: app/templates/alignment/enter.html:373
 msgid "Nepal Bhasa (Newari)"
 msgstr "Nepal Bhasa (Newari)"
 
-#: app/templates/alignment/enter.html:200
-#: app/templates/alignment/enter.html:345
+#: app/templates/alignment/enter.html:229
+#: app/templates/alignment/enter.html:374
 msgid "Nepali"
 msgstr "Nepali"
 
-#: app/templates/alignment/enter.html:201
-#: app/templates/alignment/enter.html:346
+#: app/templates/alignment/enter.html:230
+#: app/templates/alignment/enter.html:375
 msgid "Newari (Classical)"
 msgstr "Newari (Classical)"
 
-#: app/templates/alignment/enter.html:202
-#: app/templates/alignment/enter.html:347
+#: app/templates/alignment/enter.html:231
+#: app/templates/alignment/enter.html:376
 msgid "Norse (Old)"
 msgstr "Norse (Old)"
 
-#: app/templates/alignment/enter.html:203
-#: app/templates/alignment/enter.html:348
+#: app/templates/alignment/enter.html:232
+#: app/templates/alignment/enter.html:377
 msgid "Norwegian"
 msgstr "Norwegian"
 
-#: app/templates/alignment/enter.html:204
-#: app/templates/alignment/enter.html:349
+#: app/templates/alignment/enter.html:233
+#: app/templates/alignment/enter.html:378
 msgid "Norwegian (Bokmål)"
 msgstr "Norwegian (Bokmål)"
 
-#: app/templates/alignment/enter.html:205
-#: app/templates/alignment/enter.html:350
+#: app/templates/alignment/enter.html:234
+#: app/templates/alignment/enter.html:379
 msgid "Norwegian (Nynorsk)"
 msgstr "Norwegian (Nynorsk)"
 
-#: app/templates/alignment/enter.html:206
-#: app/templates/alignment/enter.html:351
+#: app/templates/alignment/enter.html:235
+#: app/templates/alignment/enter.html:380
 msgid "Ossetian"
 msgstr "Ossetian"
 
-#: app/templates/alignment/enter.html:207
-#: app/templates/alignment/enter.html:352
+#: app/templates/alignment/enter.html:236
+#: app/templates/alignment/enter.html:381
 msgid "Pahlavi (Middle Persian)"
 msgstr "Pahlavi (Middle Persian)"
 
-#: app/templates/alignment/enter.html:208
-#: app/templates/alignment/enter.html:353
+#: app/templates/alignment/enter.html:237
+#: app/templates/alignment/enter.html:382
 msgid "Pali"
 msgstr "Pali"
 
-#: app/templates/alignment/enter.html:209
-#: app/templates/alignment/enter.html:354
+#: app/templates/alignment/enter.html:238
+#: app/templates/alignment/enter.html:383
 msgid "Pashto"
 msgstr "Pashto"
 
-#: app/templates/alignment/enter.html:210
-#: app/templates/alignment/enter.html:355
+#: app/templates/alignment/enter.html:239
+#: app/templates/alignment/enter.html:384
 msgid "Persian (Farsi)"
 msgstr "Persian (Farsi)"
 
-#: app/templates/alignment/enter.html:211
-#: app/templates/alignment/enter.html:356
+#: app/templates/alignment/enter.html:240
+#: app/templates/alignment/enter.html:385
 msgid "Persian (Old, 600-400 BC)"
 msgstr "Persian (Old, 600-400 BC)"
 
-#: app/templates/alignment/enter.html:212
-#: app/templates/alignment/enter.html:357
+#: app/templates/alignment/enter.html:241
+#: app/templates/alignment/enter.html:386
 msgid "Phoenician"
 msgstr "Phoenician"
 
-#: app/templates/alignment/enter.html:213
-#: app/templates/alignment/enter.html:358
+#: app/templates/alignment/enter.html:242
+#: app/templates/alignment/enter.html:387
 msgid "Polish"
 msgstr "Polish"
 
-#: app/templates/alignment/enter.html:214
-#: app/templates/alignment/enter.html:359
+#: app/templates/alignment/enter.html:243
+#: app/templates/alignment/enter.html:388
 msgid "Portuguese"
 msgstr "Portuguese"
 
-#: app/templates/alignment/enter.html:215
-#: app/templates/alignment/enter.html:360
+#: app/templates/alignment/enter.html:244
+#: app/templates/alignment/enter.html:389
 msgid "Prakrit"
 msgstr "Prakrit"
 
-#: app/templates/alignment/enter.html:216
-#: app/templates/alignment/enter.html:361
+#: app/templates/alignment/enter.html:245
+#: app/templates/alignment/enter.html:390
 msgid "Provençal (Occitan, -1500)"
 msgstr "Provençal (Occitan, -1500)"
 
-#: app/templates/alignment/enter.html:217
-#: app/templates/alignment/enter.html:362
+#: app/templates/alignment/enter.html:246
+#: app/templates/alignment/enter.html:391
 msgid "Punjabi (Panjabi)"
 msgstr "Punjabi (Panjabi)"
 
-#: app/templates/alignment/enter.html:218
-#: app/templates/alignment/enter.html:363
+#: app/templates/alignment/enter.html:247
+#: app/templates/alignment/enter.html:392
 msgid "Rajasthani"
 msgstr "Rajasthani"
 
-#: app/templates/alignment/enter.html:219
-#: app/templates/alignment/enter.html:364
+#: app/templates/alignment/enter.html:248
+#: app/templates/alignment/enter.html:393
 msgid "Romanian"
 msgstr "Romanian"
 
-#: app/templates/alignment/enter.html:220
-#: app/templates/alignment/enter.html:365
+#: app/templates/alignment/enter.html:249
+#: app/templates/alignment/enter.html:394
 msgid "Romany"
 msgstr "Romany"
 
-#: app/templates/alignment/enter.html:221
-#: app/templates/alignment/enter.html:366
+#: app/templates/alignment/enter.html:250
+#: app/templates/alignment/enter.html:395
 msgid "Russian"
 msgstr "Russian"
 
-#: app/templates/alignment/enter.html:222
-#: app/templates/alignment/enter.html:367
+#: app/templates/alignment/enter.html:251
+#: app/templates/alignment/enter.html:396
 msgid "Sanskrit"
 msgstr "Sanskrit"
 
-#: app/templates/alignment/enter.html:223
-#: app/templates/alignment/enter.html:368
+#: app/templates/alignment/enter.html:252
+#: app/templates/alignment/enter.html:397
 msgid "Scots"
 msgstr "Scots"
 
-#: app/templates/alignment/enter.html:224
-#: app/templates/alignment/enter.html:369
+#: app/templates/alignment/enter.html:253
+#: app/templates/alignment/enter.html:398
 msgid "Scottish (Gaelic)"
 msgstr "Scottish (Gaelic)"
 
-#: app/templates/alignment/enter.html:225
-#: app/templates/alignment/enter.html:370
+#: app/templates/alignment/enter.html:254
+#: app/templates/alignment/enter.html:399
 msgid "Serbian"
 msgstr "Serbian"
 
-#: app/templates/alignment/enter.html:226
-#: app/templates/alignment/enter.html:371
+#: app/templates/alignment/enter.html:255
+#: app/templates/alignment/enter.html:400
 msgid "Sicilian"
 msgstr "Sicilian"
 
-#: app/templates/alignment/enter.html:227
-#: app/templates/alignment/enter.html:372
+#: app/templates/alignment/enter.html:256
+#: app/templates/alignment/enter.html:401
 msgid "Sindhi"
 msgstr "Sindhi"
 
-#: app/templates/alignment/enter.html:228
-#: app/templates/alignment/enter.html:373
+#: app/templates/alignment/enter.html:257
+#: app/templates/alignment/enter.html:402
 msgid "Sinhalese (Sinhala)"
 msgstr "Sinhalese (Sinhala)"
 
-#: app/templates/alignment/enter.html:229
-#: app/templates/alignment/enter.html:374
+#: app/templates/alignment/enter.html:258
+#: app/templates/alignment/enter.html:403
 msgid "Slovak"
 msgstr "Slovak"
 
-#: app/templates/alignment/enter.html:230
-#: app/templates/alignment/enter.html:375
+#: app/templates/alignment/enter.html:259
+#: app/templates/alignment/enter.html:404
 msgid "Slovenian"
 msgstr "Slovenian"
 
-#: app/templates/alignment/enter.html:231
-#: app/templates/alignment/enter.html:376
+#: app/templates/alignment/enter.html:260
+#: app/templates/alignment/enter.html:405
 msgid "Sogdian"
 msgstr "Sogdian"
 
-#: app/templates/alignment/enter.html:232
-#: app/templates/alignment/enter.html:377
+#: app/templates/alignment/enter.html:261
+#: app/templates/alignment/enter.html:406
 msgid "Spanish (Castilian)"
 msgstr "Spanish (Castilian)"
 
-#: app/templates/alignment/enter.html:233
-#: app/templates/alignment/enter.html:378
+#: app/templates/alignment/enter.html:262
+#: app/templates/alignment/enter.html:407
 msgid "Sumerian"
 msgstr "Sumerian"
 
-#: app/templates/alignment/enter.html:234
-#: app/templates/alignment/enter.html:379
+#: app/templates/alignment/enter.html:263
+#: app/templates/alignment/enter.html:408
 msgid "Swahili"
 msgstr "Swahili"
 
-#: app/templates/alignment/enter.html:235
-#: app/templates/alignment/enter.html:380
+#: app/templates/alignment/enter.html:264
+#: app/templates/alignment/enter.html:409
 msgid "Swedish"
 msgstr "Swedish"
 
-#: app/templates/alignment/enter.html:236
-#: app/templates/alignment/enter.html:381
+#: app/templates/alignment/enter.html:265
+#: app/templates/alignment/enter.html:410
 msgid "Swiss German (Alsatian)"
 msgstr "Swiss German (Alsatian)"
 
-#: app/templates/alignment/enter.html:237
-#: app/templates/alignment/enter.html:382
+#: app/templates/alignment/enter.html:266
+#: app/templates/alignment/enter.html:411
 msgid "Syriac (Classical)"
 msgstr "Syriac (Classical)"
 
-#: app/templates/alignment/enter.html:238
-#: app/templates/alignment/enter.html:383
+#: app/templates/alignment/enter.html:267
+#: app/templates/alignment/enter.html:412
 msgid "Syriac (Northeastern, Neo-Aramaic)"
 msgstr "Syriac (Northeastern, Neo-Aramaic)"
 
-#: app/templates/alignment/enter.html:239
-#: app/templates/alignment/enter.html:384
+#: app/templates/alignment/enter.html:268
+#: app/templates/alignment/enter.html:413
 msgid "Tagalog"
 msgstr "Tagalog"
 
-#: app/templates/alignment/enter.html:240
-#: app/templates/alignment/enter.html:385
+#: app/templates/alignment/enter.html:269
+#: app/templates/alignment/enter.html:414
 msgid "Tajik"
 msgstr "Tajik"
 
-#: app/templates/alignment/enter.html:241
-#: app/templates/alignment/enter.html:386
+#: app/templates/alignment/enter.html:270
+#: app/templates/alignment/enter.html:415
 msgid "Tamil"
 msgstr "Tamil"
 
-#: app/templates/alignment/enter.html:242
-#: app/templates/alignment/enter.html:387
+#: app/templates/alignment/enter.html:271
+#: app/templates/alignment/enter.html:416
 msgid "Tatar"
 msgstr "Tatar"
 
-#: app/templates/alignment/enter.html:243
-#: app/templates/alignment/enter.html:388
+#: app/templates/alignment/enter.html:272
+#: app/templates/alignment/enter.html:417
 msgid "Telugu"
 msgstr "Telugu"
 
-#: app/templates/alignment/enter.html:244
-#: app/templates/alignment/enter.html:389
+#: app/templates/alignment/enter.html:273
+#: app/templates/alignment/enter.html:418
 msgid "Thai"
 msgstr "Thai"
 
-#: app/templates/alignment/enter.html:245
-#: app/templates/alignment/enter.html:390
+#: app/templates/alignment/enter.html:274
+#: app/templates/alignment/enter.html:419
 msgid "Tibetan"
 msgstr "Tibetan"
 
-#: app/templates/alignment/enter.html:246
-#: app/templates/alignment/enter.html:391
+#: app/templates/alignment/enter.html:275
+#: app/templates/alignment/enter.html:420
 msgid "Turkish (Modern)"
 msgstr "Turkish (Modern)"
 
-#: app/templates/alignment/enter.html:247
-#: app/templates/alignment/enter.html:392
+#: app/templates/alignment/enter.html:276
+#: app/templates/alignment/enter.html:421
 msgid "Turkish (Ottoman, 1500-1928 )"
 msgstr "Turkish (Ottoman, 1500-1928 )"
 
-#: app/templates/alignment/enter.html:248
-#: app/templates/alignment/enter.html:393
+#: app/templates/alignment/enter.html:277
+#: app/templates/alignment/enter.html:422
 msgid "Turkmen"
 msgstr "Turkmen"
 
-#: app/templates/alignment/enter.html:249
-#: app/templates/alignment/enter.html:394
+#: app/templates/alignment/enter.html:278
+#: app/templates/alignment/enter.html:423
 msgid "Ugaritic"
 msgstr "Ugaritic"
 
-#: app/templates/alignment/enter.html:250
-#: app/templates/alignment/enter.html:395
+#: app/templates/alignment/enter.html:279
+#: app/templates/alignment/enter.html:424
 msgid "Ukainian"
 msgstr "Ukainian"
 
-#: app/templates/alignment/enter.html:251
-#: app/templates/alignment/enter.html:396
+#: app/templates/alignment/enter.html:280
+#: app/templates/alignment/enter.html:425
 msgid "Urdu"
 msgstr "Urdu"
 
-#: app/templates/alignment/enter.html:252
-#: app/templates/alignment/enter.html:397
+#: app/templates/alignment/enter.html:281
+#: app/templates/alignment/enter.html:426
 msgid "Uzbek"
 msgstr "Uzbek"
 
-#: app/templates/alignment/enter.html:253
-#: app/templates/alignment/enter.html:398
+#: app/templates/alignment/enter.html:282
+#: app/templates/alignment/enter.html:427
 msgid "Vietnamese"
 msgstr "Vietnamese"
 
-#: app/templates/alignment/enter.html:254
-#: app/templates/alignment/enter.html:399
+#: app/templates/alignment/enter.html:283
+#: app/templates/alignment/enter.html:428
 msgid "Walloon"
 msgstr "Walloon"
 
-#: app/templates/alignment/enter.html:255
-#: app/templates/alignment/enter.html:400
+#: app/templates/alignment/enter.html:284
+#: app/templates/alignment/enter.html:429
 msgid "Welsh"
 msgstr "Welsh"
 
-#: app/templates/alignment/enter.html:256
-#: app/templates/alignment/enter.html:401
+#: app/templates/alignment/enter.html:285
+#: app/templates/alignment/enter.html:430
 msgid "Yiddish"
 msgstr "Yiddish"
 
-#: app/templates/alignment/enter.html:260
-#: app/templates/alignment/enter.html:405
+#: app/templates/alignment/enter.html:289
+#: app/templates/alignment/enter.html:434
 msgid "Other*:"
 msgstr "Other*:"
 
-#: app/templates/alignment/enter.html:265
-#: app/templates/alignment/enter.html:410
-#: app/templates/treebank/enter.html:112
+#: app/templates/alignment/enter.html:294
+#: app/templates/alignment/enter.html:439 app/templates/treebank/enter.html:112
 msgid "Click  to toggle advanced options..."
 msgstr "Click  to toggle advanced options..."
 
-#: app/templates/alignment/enter.html:271
+#: app/templates/alignment/enter.html:300
 msgid "Language 2:"
 msgstr "Language 2:"
 
-#: app/templates/alignment/enter.html:314
+#: app/templates/alignment/enter.html:343
 msgid "French (Old, 842-c. 1400)"
 msgstr "French (Old, 842-c. 1400)"
 
-#: app/templates/alignment/enter.html:415
-msgid "*Please use ISO 639-2 or ISO 639-3 three-letter codes for any other languages"
-msgstr "*Please use ISO 639-2 or ISO 639-3 three-letter codes for any other languages"
+#: app/templates/alignment/enter.html:444
+msgid ""
+"*Please use ISO 639-2 or ISO 639-3 three-letter codes for any other "
+"languages"
+msgstr ""
+"*Please use ISO 639-2 or ISO 639-3 three-letter codes for any other "
+"languages"
 
-#: app/templates/alignment/enter.html:419
+#: app/templates/alignment/enter.html:448
 msgid "Align"
 msgstr "Align"
 
@@ -764,10 +788,6 @@ msgstr "Search for a text"
 #: app/templates/treebank/enter.html:72
 msgid "Enter your own text URI :"
 msgstr "Enter your own text URI :"
-
-#: app/templates/treebank/enter.html:78
-msgid "Select"
-msgstr "Select"
 
 #: app/templates/treebank/enter.html:87
 msgid "Language:"
@@ -937,3 +957,7 @@ msgstr "Create Link"
 
 #~ msgid "French \\(Old, 842-c. 1400\\)"
 #~ msgstr ""
+
+#~ msgid "Text URI"
+#~ msgstr "Text URI"
+

--- a/app/translations/fr/LC_MESSAGES/messages.po
+++ b/app/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-03-27 13:25+0000\n"
+"POT-Creation-Date: 2015-04-13 18:10+0000\n"
 "PO-Revision-Date: 2015-03-27 09:37-0500\n"
 "Last-Translator: Bridget Almas <balmas@gmail.com>\n"
 "Language-Team: fr <LL@li.org>\n"
@@ -17,734 +17,758 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 1.3\n"
 
-#: app/templates/alignment/enter.html:77
+#: app/templates/alignment/enter.html:72
+msgid "Switch to prior version of this form"
+msgstr ""
+
+#: app/templates/alignment/enter.html:82
 msgid "Enter Metadata:"
 msgstr "Enter Metadata:"
 
-#: app/templates/alignment/enter.html:78
+#: app/templates/alignment/enter.html:83
 msgid "Alignment title:"
 msgstr "Alignment title:"
 
-#: app/templates/alignment/enter.html:78
+#: app/templates/alignment/enter.html:83
 msgid "alignmenttitlehint"
-msgstr "e.g. \"Alignment of Thuc. 1.1 in French and English\" (100 chars max restricted to alphanumerics and '.','_' and '-')"
+msgstr ""
+"e.g. \"Alignment of Thuc. 1.1 in French and English\" (100 chars max "
+"restricted to alphanumerics and '.','_' and '-')"
 
-#: app/templates/alignment/enter.html:79
+#: app/templates/alignment/enter.html:84
 msgid "Enter a short title for your annotation"
 msgstr "Enter a short title for your annotation"
 
-#: app/templates/alignment/enter.html:85
+#: app/templates/alignment/enter.html:90
 msgid "Enter Text in Language 1:"
 msgstr "Enter Text in Language 1:"
 
-#: app/templates/alignment/enter.html:87
-#: app/templates/alignment/enter.html:107
+#: app/templates/alignment/enter.html:92 app/templates/alignment/enter.html:124
 #: app/templates/treebank/enter.html:98
 msgid "Text Direction:"
 msgstr "Sens de lecture:"
 
-#: app/templates/alignment/enter.html:89
-#: app/templates/alignment/enter.html:109
+#: app/templates/alignment/enter.html:94 app/templates/alignment/enter.html:126
 #: app/templates/treebank/enter.html:100
 msgid "Left to Right"
 msgstr "De gauche à droite"
 
-#: app/templates/alignment/enter.html:91
-#: app/templates/alignment/enter.html:111
+#: app/templates/alignment/enter.html:96 app/templates/alignment/enter.html:128
 #: app/templates/treebank/enter.html:102
 msgid "Right to Left"
 msgstr "De droite à gauche"
 
-#: app/templates/alignment/enter.html:96
-#: app/templates/alignment/enter.html:115
-#: app/templates/treebank/enter.html:65
+#: app/templates/alignment/enter.html:101
+#: app/templates/alignment/enter.html:118
+#: app/templates/alignment/enter.html:132
+#: app/templates/alignment/enter.html:148 app/templates/treebank/enter.html:65
 #: app/templates/treebank/enter.html:81
 msgid "Invalid entry"
 msgstr "Entrée invalide"
 
-#: app/templates/alignment/enter.html:100
-#: app/templates/alignment/enter.html:118
-msgid "Text URI"
-msgstr "Text URI"
-
 #: app/templates/alignment/enter.html:105
+#: app/templates/alignment/enter.html:135
+#, fuzzy
+msgid "Search for a text:"
+msgstr "Chercher un texte"
+
+#: app/templates/alignment/enter.html:106
+#: app/templates/alignment/enter.html:136
+msgid ""
+"URI Identifer for this text. If a URL, text will be loaded from there. "
+"Plain text only supported."
+msgstr ""
+
+#: app/templates/alignment/enter.html:109
+#: app/templates/alignment/enter.html:139
+#, fuzzy
+msgid "Or enter your own text URI:"
+msgstr "Entrer une addresse particulière pour un texte:"
+
+#: app/templates/alignment/enter.html:115
+#: app/templates/alignment/enter.html:145 app/templates/treebank/enter.html:78
+msgid "Select"
+msgstr "Sélectionner"
+
+#: app/templates/alignment/enter.html:122
 msgid "Enter Text in Language 2:"
 msgstr "Enter Text in Language 2:"
 
-#: app/templates/alignment/enter.html:126
+#: app/templates/alignment/enter.html:155
 msgid "Language 1:"
 msgstr "Langue 1:"
 
-#: app/templates/alignment/enter.html:128
-#: app/templates/alignment/enter.html:273
+#: app/templates/alignment/enter.html:157
+#: app/templates/alignment/enter.html:302
 msgid "English"
 msgstr "English"
 
-#: app/templates/alignment/enter.html:129
-#: app/templates/alignment/enter.html:274
-#: app/templates/treebank/enter.html:91
+#: app/templates/alignment/enter.html:158
+#: app/templates/alignment/enter.html:303 app/templates/treebank/enter.html:91
 msgid "Latin"
 msgstr "Latin"
 
-#: app/templates/alignment/enter.html:130
-#: app/templates/alignment/enter.html:275
+#: app/templates/alignment/enter.html:159
+#: app/templates/alignment/enter.html:304
 msgid "Greek (Ancient -1453)"
 msgstr "Greek (Ancient -1453)"
 
-#: app/templates/alignment/enter.html:131
-#: app/templates/alignment/enter.html:276
-#: app/templates/treebank/enter.html:93
+#: app/templates/alignment/enter.html:160
+#: app/templates/alignment/enter.html:305 app/templates/treebank/enter.html:93
 msgid "Arabic"
 msgstr "Arabe"
 
-#: app/templates/alignment/enter.html:132
-#: app/templates/alignment/enter.html:277
+#: app/templates/alignment/enter.html:161
+#: app/templates/alignment/enter.html:306
 msgid "Chinese"
 msgstr "Chinese"
 
-#: app/templates/alignment/enter.html:133
-#: app/templates/alignment/enter.html:278
+#: app/templates/alignment/enter.html:162
+#: app/templates/alignment/enter.html:307
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
-#: app/templates/alignment/enter.html:134
-#: app/templates/alignment/enter.html:279
+#: app/templates/alignment/enter.html:163
+#: app/templates/alignment/enter.html:308
 msgid "Akkadian"
 msgstr "Akkadian"
 
-#: app/templates/alignment/enter.html:135
-#: app/templates/alignment/enter.html:280
+#: app/templates/alignment/enter.html:164
+#: app/templates/alignment/enter.html:309
 msgid "Albanian"
 msgstr "Albanian"
 
-#: app/templates/alignment/enter.html:136
-#: app/templates/alignment/enter.html:281
+#: app/templates/alignment/enter.html:165
+#: app/templates/alignment/enter.html:310
 msgid "Amharic"
 msgstr "Amharic"
 
-#: app/templates/alignment/enter.html:137
-#: app/templates/alignment/enter.html:282
+#: app/templates/alignment/enter.html:166
+#: app/templates/alignment/enter.html:311
 msgid "Aragonese"
 msgstr "Aragonese"
 
-#: app/templates/alignment/enter.html:138
-#: app/templates/alignment/enter.html:283
+#: app/templates/alignment/enter.html:167
+#: app/templates/alignment/enter.html:312
 msgid "Aramaic (Imperial- 700 BC-300 BC)"
 msgstr "Aramaic (Imperial- 700 BC-300 BC)"
 
-#: app/templates/alignment/enter.html:139
-#: app/templates/alignment/enter.html:284
+#: app/templates/alignment/enter.html:168
+#: app/templates/alignment/enter.html:313
 msgid "Aramaic (Samaritan)"
 msgstr "Aramaic (Samaritan)"
 
-#: app/templates/alignment/enter.html:140
-#: app/templates/alignment/enter.html:285
+#: app/templates/alignment/enter.html:169
+#: app/templates/alignment/enter.html:314
 msgid "Armenian"
 msgstr "Armenian"
 
-#: app/templates/alignment/enter.html:141
-#: app/templates/alignment/enter.html:286
+#: app/templates/alignment/enter.html:170
+#: app/templates/alignment/enter.html:315
 msgid "Asturian (Bable, Leonese)"
 msgstr "Asturian (Bable, Leonese)"
 
-#: app/templates/alignment/enter.html:142
-#: app/templates/alignment/enter.html:287
+#: app/templates/alignment/enter.html:171
+#: app/templates/alignment/enter.html:316
 msgid "Avestan"
 msgstr "Avestan"
 
-#: app/templates/alignment/enter.html:143
-#: app/templates/alignment/enter.html:288
+#: app/templates/alignment/enter.html:172
+#: app/templates/alignment/enter.html:317
 msgid "Azerbaijani"
 msgstr "Azerbaijani"
 
-#: app/templates/alignment/enter.html:144
-#: app/templates/alignment/enter.html:289
+#: app/templates/alignment/enter.html:173
+#: app/templates/alignment/enter.html:318
 msgid "Basque"
 msgstr "Basque"
 
-#: app/templates/alignment/enter.html:145
-#: app/templates/alignment/enter.html:290
+#: app/templates/alignment/enter.html:174
+#: app/templates/alignment/enter.html:319
 msgid "Bengali"
 msgstr "Bengali"
 
-#: app/templates/alignment/enter.html:146
-#: app/templates/alignment/enter.html:291
+#: app/templates/alignment/enter.html:175
+#: app/templates/alignment/enter.html:320
 msgid "Berber"
 msgstr "Berber"
 
-#: app/templates/alignment/enter.html:147
-#: app/templates/alignment/enter.html:292
+#: app/templates/alignment/enter.html:176
+#: app/templates/alignment/enter.html:321
 msgid "Bosnian"
 msgstr "Bosnian"
 
-#: app/templates/alignment/enter.html:148
-#: app/templates/alignment/enter.html:293
+#: app/templates/alignment/enter.html:177
+#: app/templates/alignment/enter.html:322
 msgid "Breton"
 msgstr "Breton"
 
-#: app/templates/alignment/enter.html:149
-#: app/templates/alignment/enter.html:294
+#: app/templates/alignment/enter.html:178
+#: app/templates/alignment/enter.html:323
 msgid "Bulgarian"
 msgstr "Bulgarian"
 
-#: app/templates/alignment/enter.html:150
-#: app/templates/alignment/enter.html:295
+#: app/templates/alignment/enter.html:179
+#: app/templates/alignment/enter.html:324
 msgid "Bulgarian (Old, Old Church Slavonic)"
 msgstr "Bulgarian (Old, Old Church Slavonic)"
 
-#: app/templates/alignment/enter.html:151
-#: app/templates/alignment/enter.html:296
+#: app/templates/alignment/enter.html:180
+#: app/templates/alignment/enter.html:325
 msgid "Burmese"
 msgstr "Burmese"
 
-#: app/templates/alignment/enter.html:152
-#: app/templates/alignment/enter.html:297
+#: app/templates/alignment/enter.html:181
+#: app/templates/alignment/enter.html:326
 msgid "Catalan"
 msgstr "Catalan"
 
-#: app/templates/alignment/enter.html:153
-#: app/templates/alignment/enter.html:298
+#: app/templates/alignment/enter.html:182
+#: app/templates/alignment/enter.html:327
 msgid "Chagatai"
 msgstr "Chagatai"
 
-#: app/templates/alignment/enter.html:154
-#: app/templates/alignment/enter.html:299
+#: app/templates/alignment/enter.html:183
+#: app/templates/alignment/enter.html:328
 msgid "Coptic"
 msgstr "Coptic"
 
-#: app/templates/alignment/enter.html:155
-#: app/templates/alignment/enter.html:300
+#: app/templates/alignment/enter.html:184
+#: app/templates/alignment/enter.html:329
 msgid "Cornish"
 msgstr "Cornish"
 
-#: app/templates/alignment/enter.html:156
-#: app/templates/alignment/enter.html:301
+#: app/templates/alignment/enter.html:185
+#: app/templates/alignment/enter.html:330
 msgid "Croatian"
 msgstr "Croatian"
 
-#: app/templates/alignment/enter.html:157
-#: app/templates/alignment/enter.html:302
+#: app/templates/alignment/enter.html:186
+#: app/templates/alignment/enter.html:331
 msgid "Czech"
 msgstr "Czech"
 
-#: app/templates/alignment/enter.html:158
-#: app/templates/alignment/enter.html:303
+#: app/templates/alignment/enter.html:187
+#: app/templates/alignment/enter.html:332
 msgid "Danish"
 msgstr "Danish"
 
-#: app/templates/alignment/enter.html:159
-#: app/templates/alignment/enter.html:304
+#: app/templates/alignment/enter.html:188
+#: app/templates/alignment/enter.html:333
 msgid "Dutch (Flemish)"
 msgstr "Dutch (Flemish)"
 
-#: app/templates/alignment/enter.html:160
-#: app/templates/alignment/enter.html:305
+#: app/templates/alignment/enter.html:189
+#: app/templates/alignment/enter.html:334
 msgid "Dutch (Middle, 1050-1350)"
 msgstr "Dutch (Middle, 1050-1350)"
 
-#: app/templates/alignment/enter.html:161
-#: app/templates/alignment/enter.html:306
+#: app/templates/alignment/enter.html:190
+#: app/templates/alignment/enter.html:335
 msgid "Egyptian (Ancient)"
 msgstr "Egyptian (Ancient)"
 
-#: app/templates/alignment/enter.html:162
-#: app/templates/alignment/enter.html:307
+#: app/templates/alignment/enter.html:191
+#: app/templates/alignment/enter.html:336
 msgid "Elamite"
 msgstr "Elamite"
 
-#: app/templates/alignment/enter.html:163
-#: app/templates/alignment/enter.html:308
+#: app/templates/alignment/enter.html:192
+#: app/templates/alignment/enter.html:337
 msgid "English (Middle, 1100-1500)"
 msgstr "English (Middle, 1100-1500)"
 
-#: app/templates/alignment/enter.html:164
-#: app/templates/alignment/enter.html:309
+#: app/templates/alignment/enter.html:193
+#: app/templates/alignment/enter.html:338
 msgid "English (Old, 450-1100)"
 msgstr "English (Old, 450-1100)"
 
-#: app/templates/alignment/enter.html:165
-#: app/templates/alignment/enter.html:310
+#: app/templates/alignment/enter.html:194
+#: app/templates/alignment/enter.html:339
 msgid "Estonian"
 msgstr "Estonian"
 
-#: app/templates/alignment/enter.html:166
-#: app/templates/alignment/enter.html:311
+#: app/templates/alignment/enter.html:195
+#: app/templates/alignment/enter.html:340
 msgid "Finnish"
 msgstr "Finnish"
 
-#: app/templates/alignment/enter.html:167
-#: app/templates/alignment/enter.html:312
+#: app/templates/alignment/enter.html:196
+#: app/templates/alignment/enter.html:341
 msgid "French"
 msgstr "French"
 
-#: app/templates/alignment/enter.html:168
-#: app/templates/alignment/enter.html:313
+#: app/templates/alignment/enter.html:197
+#: app/templates/alignment/enter.html:342
 msgid "French (Middle, 1400-1600)"
 msgstr "French (Middle, 1400-1600)"
 
-#: app/templates/alignment/enter.html:169
+#: app/templates/alignment/enter.html:198
 msgid "French (Old, 842c. 1400)"
 msgstr "French (Old, 842c. 1400)"
 
-#: app/templates/alignment/enter.html:170
-#: app/templates/alignment/enter.html:315
+#: app/templates/alignment/enter.html:199
+#: app/templates/alignment/enter.html:344
 msgid "Ge'ez"
 msgstr "Ge'ez"
 
-#: app/templates/alignment/enter.html:171
-#: app/templates/alignment/enter.html:316
+#: app/templates/alignment/enter.html:200
+#: app/templates/alignment/enter.html:345
 msgid "Georgian"
 msgstr "Georgian"
 
-#: app/templates/alignment/enter.html:172
-#: app/templates/alignment/enter.html:317
+#: app/templates/alignment/enter.html:201
+#: app/templates/alignment/enter.html:346
 msgid "German (Low, Low Saxon)"
 msgstr "German (Low, Low Saxon)"
 
-#: app/templates/alignment/enter.html:173
-#: app/templates/alignment/enter.html:318
+#: app/templates/alignment/enter.html:202
+#: app/templates/alignment/enter.html:347
 msgid "German (Middle-High, 1050-1500)"
 msgstr "German (Middle-High, 1050-1500)"
 
-#: app/templates/alignment/enter.html:174
-#: app/templates/alignment/enter.html:319
+#: app/templates/alignment/enter.html:203
+#: app/templates/alignment/enter.html:348
 msgid "German (Old-High, 750-1050)"
 msgstr "German (Old-High, 750-1050)"
 
-#: app/templates/alignment/enter.html:175
-#: app/templates/alignment/enter.html:320
+#: app/templates/alignment/enter.html:204
+#: app/templates/alignment/enter.html:349
 msgid "German"
 msgstr "German"
 
-#: app/templates/alignment/enter.html:176
-#: app/templates/alignment/enter.html:321
+#: app/templates/alignment/enter.html:205
+#: app/templates/alignment/enter.html:350
 msgid "Gothic"
 msgstr "Gothic"
 
-#: app/templates/alignment/enter.html:177
-#: app/templates/alignment/enter.html:322
+#: app/templates/alignment/enter.html:206
+#: app/templates/alignment/enter.html:351
 msgid "Greek (Modern, 1453-)"
 msgstr "Greek (Modern, 1453-)"
 
-#: app/templates/alignment/enter.html:178
-#: app/templates/alignment/enter.html:323
+#: app/templates/alignment/enter.html:207
+#: app/templates/alignment/enter.html:352
 msgid "Gujarati"
 msgstr "Gujarati"
 
-#: app/templates/alignment/enter.html:179
-#: app/templates/alignment/enter.html:324
+#: app/templates/alignment/enter.html:208
+#: app/templates/alignment/enter.html:353
 msgid "Hebrew"
 msgstr "Hebrew"
 
-#: app/templates/alignment/enter.html:180
-#: app/templates/alignment/enter.html:325
+#: app/templates/alignment/enter.html:209
+#: app/templates/alignment/enter.html:354
 msgid "Hindi"
 msgstr "Hindi"
 
-#: app/templates/alignment/enter.html:181
-#: app/templates/alignment/enter.html:326
+#: app/templates/alignment/enter.html:210
+#: app/templates/alignment/enter.html:355
 msgid "Hittite"
 msgstr "Hittite"
 
-#: app/templates/alignment/enter.html:182
-#: app/templates/alignment/enter.html:327
+#: app/templates/alignment/enter.html:211
+#: app/templates/alignment/enter.html:356
 msgid "Hungarian"
 msgstr "Hungarian"
 
-#: app/templates/alignment/enter.html:183
-#: app/templates/alignment/enter.html:328
+#: app/templates/alignment/enter.html:212
+#: app/templates/alignment/enter.html:357
 msgid "Icelandic"
 msgstr "Icelandic"
 
-#: app/templates/alignment/enter.html:184
-#: app/templates/alignment/enter.html:329
+#: app/templates/alignment/enter.html:213
+#: app/templates/alignment/enter.html:358
 msgid "Indonesian"
 msgstr "Indonesian"
 
-#: app/templates/alignment/enter.html:185
-#: app/templates/alignment/enter.html:330
+#: app/templates/alignment/enter.html:214
+#: app/templates/alignment/enter.html:359
 msgid "Irish (Modern)"
 msgstr "Irish (Modern)"
 
-#: app/templates/alignment/enter.html:186
-#: app/templates/alignment/enter.html:331
+#: app/templates/alignment/enter.html:215
+#: app/templates/alignment/enter.html:360
 msgid "Irish (Middle 900-1200)"
 msgstr "Irish (Middle 900-1200)"
 
-#: app/templates/alignment/enter.html:187
-#: app/templates/alignment/enter.html:332
+#: app/templates/alignment/enter.html:216
+#: app/templates/alignment/enter.html:361
 msgid "Irish (Old, to 900)"
 msgstr "Irish (Old, to 900)"
 
-#: app/templates/alignment/enter.html:188
-#: app/templates/alignment/enter.html:333
+#: app/templates/alignment/enter.html:217
+#: app/templates/alignment/enter.html:362
 msgid "Italian"
 msgstr "Italian"
 
-#: app/templates/alignment/enter.html:189
-#: app/templates/alignment/enter.html:334
+#: app/templates/alignment/enter.html:218
+#: app/templates/alignment/enter.html:363
 msgid "Japanese"
 msgstr "Japanese"
 
-#: app/templates/alignment/enter.html:190
-#: app/templates/alignment/enter.html:335
+#: app/templates/alignment/enter.html:219
+#: app/templates/alignment/enter.html:364
 msgid "Javanese"
 msgstr "Javanese"
 
-#: app/templates/alignment/enter.html:191
-#: app/templates/alignment/enter.html:336
+#: app/templates/alignment/enter.html:220
+#: app/templates/alignment/enter.html:365
 msgid "Kannada"
 msgstr "Kannada"
 
-#: app/templates/alignment/enter.html:192
-#: app/templates/alignment/enter.html:337
+#: app/templates/alignment/enter.html:221
+#: app/templates/alignment/enter.html:366
 msgid "Khmer (Central)"
 msgstr "Khmer (Central)"
 
-#: app/templates/alignment/enter.html:193
-#: app/templates/alignment/enter.html:338
+#: app/templates/alignment/enter.html:222
+#: app/templates/alignment/enter.html:367
 msgid "Korean"
 msgstr "Korean"
 
-#: app/templates/alignment/enter.html:194
-#: app/templates/alignment/enter.html:339
+#: app/templates/alignment/enter.html:223
+#: app/templates/alignment/enter.html:368
 msgid "Kurdish"
 msgstr "Kurdish"
 
-#: app/templates/alignment/enter.html:195
-#: app/templates/alignment/enter.html:340
+#: app/templates/alignment/enter.html:224
+#: app/templates/alignment/enter.html:369
 msgid "Ladino"
 msgstr "Ladino"
 
-#: app/templates/alignment/enter.html:196
-#: app/templates/alignment/enter.html:341
+#: app/templates/alignment/enter.html:225
+#: app/templates/alignment/enter.html:370
 msgid "Lithuanian"
 msgstr "Lithuanian"
 
-#: app/templates/alignment/enter.html:197
-#: app/templates/alignment/enter.html:342
+#: app/templates/alignment/enter.html:226
+#: app/templates/alignment/enter.html:371
 msgid "Malay"
 msgstr "Malay"
 
-#: app/templates/alignment/enter.html:198
-#: app/templates/alignment/enter.html:343
+#: app/templates/alignment/enter.html:227
+#: app/templates/alignment/enter.html:372
 msgid "Marathi"
 msgstr "Marathi"
 
-#: app/templates/alignment/enter.html:199
-#: app/templates/alignment/enter.html:344
+#: app/templates/alignment/enter.html:228
+#: app/templates/alignment/enter.html:373
 msgid "Nepal Bhasa (Newari)"
 msgstr "Nepal Bhasa (Newari)"
 
-#: app/templates/alignment/enter.html:200
-#: app/templates/alignment/enter.html:345
+#: app/templates/alignment/enter.html:229
+#: app/templates/alignment/enter.html:374
 msgid "Nepali"
 msgstr "Nepali"
 
-#: app/templates/alignment/enter.html:201
-#: app/templates/alignment/enter.html:346
+#: app/templates/alignment/enter.html:230
+#: app/templates/alignment/enter.html:375
 msgid "Newari (Classical)"
 msgstr "Newari (Classical)"
 
-#: app/templates/alignment/enter.html:202
-#: app/templates/alignment/enter.html:347
+#: app/templates/alignment/enter.html:231
+#: app/templates/alignment/enter.html:376
 msgid "Norse (Old)"
 msgstr "Norse (Old)"
 
-#: app/templates/alignment/enter.html:203
-#: app/templates/alignment/enter.html:348
+#: app/templates/alignment/enter.html:232
+#: app/templates/alignment/enter.html:377
 msgid "Norwegian"
 msgstr "Norwegian"
 
-#: app/templates/alignment/enter.html:204
-#: app/templates/alignment/enter.html:349
+#: app/templates/alignment/enter.html:233
+#: app/templates/alignment/enter.html:378
 msgid "Norwegian (Bokmål)"
 msgstr "Norwegian (Bokmål)"
 
-#: app/templates/alignment/enter.html:205
-#: app/templates/alignment/enter.html:350
+#: app/templates/alignment/enter.html:234
+#: app/templates/alignment/enter.html:379
 msgid "Norwegian (Nynorsk)"
 msgstr "Norwegian (Nynorsk)"
 
-#: app/templates/alignment/enter.html:206
-#: app/templates/alignment/enter.html:351
+#: app/templates/alignment/enter.html:235
+#: app/templates/alignment/enter.html:380
 msgid "Ossetian"
 msgstr "Ossetian"
 
-#: app/templates/alignment/enter.html:207
-#: app/templates/alignment/enter.html:352
+#: app/templates/alignment/enter.html:236
+#: app/templates/alignment/enter.html:381
 msgid "Pahlavi (Middle Persian)"
 msgstr "Pahlavi (Middle Persian)"
 
-#: app/templates/alignment/enter.html:208
-#: app/templates/alignment/enter.html:353
+#: app/templates/alignment/enter.html:237
+#: app/templates/alignment/enter.html:382
 msgid "Pali"
 msgstr "Pali"
 
-#: app/templates/alignment/enter.html:209
-#: app/templates/alignment/enter.html:354
+#: app/templates/alignment/enter.html:238
+#: app/templates/alignment/enter.html:383
 msgid "Pashto"
 msgstr "Pashto"
 
-#: app/templates/alignment/enter.html:210
-#: app/templates/alignment/enter.html:355
+#: app/templates/alignment/enter.html:239
+#: app/templates/alignment/enter.html:384
 msgid "Persian (Farsi)"
 msgstr "Persian (Farsi)"
 
-#: app/templates/alignment/enter.html:211
-#: app/templates/alignment/enter.html:356
+#: app/templates/alignment/enter.html:240
+#: app/templates/alignment/enter.html:385
 msgid "Persian (Old, 600-400 BC)"
 msgstr "Persian (Old, 600-400 BC)"
 
-#: app/templates/alignment/enter.html:212
-#: app/templates/alignment/enter.html:357
+#: app/templates/alignment/enter.html:241
+#: app/templates/alignment/enter.html:386
 msgid "Phoenician"
 msgstr "Phoenician"
 
-#: app/templates/alignment/enter.html:213
-#: app/templates/alignment/enter.html:358
+#: app/templates/alignment/enter.html:242
+#: app/templates/alignment/enter.html:387
 msgid "Polish"
 msgstr "Polish"
 
-#: app/templates/alignment/enter.html:214
-#: app/templates/alignment/enter.html:359
+#: app/templates/alignment/enter.html:243
+#: app/templates/alignment/enter.html:388
 msgid "Portuguese"
 msgstr "Portuguese"
 
-#: app/templates/alignment/enter.html:215
-#: app/templates/alignment/enter.html:360
+#: app/templates/alignment/enter.html:244
+#: app/templates/alignment/enter.html:389
 msgid "Prakrit"
 msgstr "Prakrit"
 
-#: app/templates/alignment/enter.html:216
-#: app/templates/alignment/enter.html:361
+#: app/templates/alignment/enter.html:245
+#: app/templates/alignment/enter.html:390
 msgid "Provençal (Occitan, -1500)"
 msgstr "Provençal (Occitan, -1500)"
 
-#: app/templates/alignment/enter.html:217
-#: app/templates/alignment/enter.html:362
+#: app/templates/alignment/enter.html:246
+#: app/templates/alignment/enter.html:391
 msgid "Punjabi (Panjabi)"
 msgstr "Punjabi (Panjabi)"
 
-#: app/templates/alignment/enter.html:218
-#: app/templates/alignment/enter.html:363
+#: app/templates/alignment/enter.html:247
+#: app/templates/alignment/enter.html:392
 msgid "Rajasthani"
 msgstr "Rajasthani"
 
-#: app/templates/alignment/enter.html:219
-#: app/templates/alignment/enter.html:364
+#: app/templates/alignment/enter.html:248
+#: app/templates/alignment/enter.html:393
 msgid "Romanian"
 msgstr "Romanian"
 
-#: app/templates/alignment/enter.html:220
-#: app/templates/alignment/enter.html:365
+#: app/templates/alignment/enter.html:249
+#: app/templates/alignment/enter.html:394
 msgid "Romany"
 msgstr "Romany"
 
-#: app/templates/alignment/enter.html:221
-#: app/templates/alignment/enter.html:366
+#: app/templates/alignment/enter.html:250
+#: app/templates/alignment/enter.html:395
 msgid "Russian"
 msgstr "Russian"
 
-#: app/templates/alignment/enter.html:222
-#: app/templates/alignment/enter.html:367
+#: app/templates/alignment/enter.html:251
+#: app/templates/alignment/enter.html:396
 msgid "Sanskrit"
 msgstr "Sanskrit"
 
-#: app/templates/alignment/enter.html:223
-#: app/templates/alignment/enter.html:368
+#: app/templates/alignment/enter.html:252
+#: app/templates/alignment/enter.html:397
 msgid "Scots"
 msgstr "Scots"
 
-#: app/templates/alignment/enter.html:224
-#: app/templates/alignment/enter.html:369
+#: app/templates/alignment/enter.html:253
+#: app/templates/alignment/enter.html:398
 msgid "Scottish (Gaelic)"
 msgstr "Scottish (Gaelic)"
 
-#: app/templates/alignment/enter.html:225
-#: app/templates/alignment/enter.html:370
+#: app/templates/alignment/enter.html:254
+#: app/templates/alignment/enter.html:399
 msgid "Serbian"
 msgstr "Serbian"
 
-#: app/templates/alignment/enter.html:226
-#: app/templates/alignment/enter.html:371
+#: app/templates/alignment/enter.html:255
+#: app/templates/alignment/enter.html:400
 msgid "Sicilian"
 msgstr "Sicilian"
 
-#: app/templates/alignment/enter.html:227
-#: app/templates/alignment/enter.html:372
+#: app/templates/alignment/enter.html:256
+#: app/templates/alignment/enter.html:401
 msgid "Sindhi"
 msgstr "Sindhi"
 
-#: app/templates/alignment/enter.html:228
-#: app/templates/alignment/enter.html:373
+#: app/templates/alignment/enter.html:257
+#: app/templates/alignment/enter.html:402
 msgid "Sinhalese (Sinhala)"
 msgstr "Sinhalese (Sinhala)"
 
-#: app/templates/alignment/enter.html:229
-#: app/templates/alignment/enter.html:374
+#: app/templates/alignment/enter.html:258
+#: app/templates/alignment/enter.html:403
 msgid "Slovak"
 msgstr "Slovak"
 
-#: app/templates/alignment/enter.html:230
-#: app/templates/alignment/enter.html:375
+#: app/templates/alignment/enter.html:259
+#: app/templates/alignment/enter.html:404
 msgid "Slovenian"
 msgstr "Slovenian"
 
-#: app/templates/alignment/enter.html:231
-#: app/templates/alignment/enter.html:376
+#: app/templates/alignment/enter.html:260
+#: app/templates/alignment/enter.html:405
 msgid "Sogdian"
 msgstr "Sogdian"
 
-#: app/templates/alignment/enter.html:232
-#: app/templates/alignment/enter.html:377
+#: app/templates/alignment/enter.html:261
+#: app/templates/alignment/enter.html:406
 msgid "Spanish (Castilian)"
 msgstr "Spanish (Castilian)"
 
-#: app/templates/alignment/enter.html:233
-#: app/templates/alignment/enter.html:378
+#: app/templates/alignment/enter.html:262
+#: app/templates/alignment/enter.html:407
 msgid "Sumerian"
 msgstr "Sumerian"
 
-#: app/templates/alignment/enter.html:234
-#: app/templates/alignment/enter.html:379
+#: app/templates/alignment/enter.html:263
+#: app/templates/alignment/enter.html:408
 msgid "Swahili"
 msgstr "Swahili"
 
-#: app/templates/alignment/enter.html:235
-#: app/templates/alignment/enter.html:380
+#: app/templates/alignment/enter.html:264
+#: app/templates/alignment/enter.html:409
 msgid "Swedish"
 msgstr "Swedish"
 
-#: app/templates/alignment/enter.html:236
-#: app/templates/alignment/enter.html:381
+#: app/templates/alignment/enter.html:265
+#: app/templates/alignment/enter.html:410
 msgid "Swiss German (Alsatian)"
 msgstr "Swiss German (Alsatian)"
 
-#: app/templates/alignment/enter.html:237
-#: app/templates/alignment/enter.html:382
+#: app/templates/alignment/enter.html:266
+#: app/templates/alignment/enter.html:411
 msgid "Syriac (Classical)"
 msgstr "Syriac (Classical)"
 
-#: app/templates/alignment/enter.html:238
-#: app/templates/alignment/enter.html:383
+#: app/templates/alignment/enter.html:267
+#: app/templates/alignment/enter.html:412
 msgid "Syriac (Northeastern, Neo-Aramaic)"
 msgstr "Syriac (Northeastern, Neo-Aramaic)"
 
-#: app/templates/alignment/enter.html:239
-#: app/templates/alignment/enter.html:384
+#: app/templates/alignment/enter.html:268
+#: app/templates/alignment/enter.html:413
 msgid "Tagalog"
 msgstr "Tagalog"
 
-#: app/templates/alignment/enter.html:240
-#: app/templates/alignment/enter.html:385
+#: app/templates/alignment/enter.html:269
+#: app/templates/alignment/enter.html:414
 msgid "Tajik"
 msgstr "Tajik"
 
-#: app/templates/alignment/enter.html:241
-#: app/templates/alignment/enter.html:386
+#: app/templates/alignment/enter.html:270
+#: app/templates/alignment/enter.html:415
 msgid "Tamil"
 msgstr "Tamil"
 
-#: app/templates/alignment/enter.html:242
-#: app/templates/alignment/enter.html:387
+#: app/templates/alignment/enter.html:271
+#: app/templates/alignment/enter.html:416
 msgid "Tatar"
 msgstr "Tatar"
 
-#: app/templates/alignment/enter.html:243
-#: app/templates/alignment/enter.html:388
+#: app/templates/alignment/enter.html:272
+#: app/templates/alignment/enter.html:417
 msgid "Telugu"
 msgstr "Telugu"
 
-#: app/templates/alignment/enter.html:244
-#: app/templates/alignment/enter.html:389
+#: app/templates/alignment/enter.html:273
+#: app/templates/alignment/enter.html:418
 msgid "Thai"
 msgstr "Thai"
 
-#: app/templates/alignment/enter.html:245
-#: app/templates/alignment/enter.html:390
+#: app/templates/alignment/enter.html:274
+#: app/templates/alignment/enter.html:419
 msgid "Tibetan"
 msgstr "Tibetan"
 
-#: app/templates/alignment/enter.html:246
-#: app/templates/alignment/enter.html:391
+#: app/templates/alignment/enter.html:275
+#: app/templates/alignment/enter.html:420
 msgid "Turkish (Modern)"
 msgstr "Turkish (Modern)"
 
-#: app/templates/alignment/enter.html:247
-#: app/templates/alignment/enter.html:392
+#: app/templates/alignment/enter.html:276
+#: app/templates/alignment/enter.html:421
 msgid "Turkish (Ottoman, 1500-1928 )"
 msgstr "Turkish (Ottoman, 1500-1928 )"
 
-#: app/templates/alignment/enter.html:248
-#: app/templates/alignment/enter.html:393
+#: app/templates/alignment/enter.html:277
+#: app/templates/alignment/enter.html:422
 msgid "Turkmen"
 msgstr "Turkmen"
 
-#: app/templates/alignment/enter.html:249
-#: app/templates/alignment/enter.html:394
+#: app/templates/alignment/enter.html:278
+#: app/templates/alignment/enter.html:423
 msgid "Ugaritic"
 msgstr "Ugaritic"
 
-#: app/templates/alignment/enter.html:250
-#: app/templates/alignment/enter.html:395
+#: app/templates/alignment/enter.html:279
+#: app/templates/alignment/enter.html:424
 msgid "Ukainian"
 msgstr "Ukainian"
 
-#: app/templates/alignment/enter.html:251
-#: app/templates/alignment/enter.html:396
+#: app/templates/alignment/enter.html:280
+#: app/templates/alignment/enter.html:425
 msgid "Urdu"
 msgstr "Urdu"
 
-#: app/templates/alignment/enter.html:252
-#: app/templates/alignment/enter.html:397
+#: app/templates/alignment/enter.html:281
+#: app/templates/alignment/enter.html:426
 msgid "Uzbek"
 msgstr "Uzbek"
 
-#: app/templates/alignment/enter.html:253
-#: app/templates/alignment/enter.html:398
+#: app/templates/alignment/enter.html:282
+#: app/templates/alignment/enter.html:427
 msgid "Vietnamese"
 msgstr "Vietnamese"
 
-#: app/templates/alignment/enter.html:254
-#: app/templates/alignment/enter.html:399
+#: app/templates/alignment/enter.html:283
+#: app/templates/alignment/enter.html:428
 msgid "Walloon"
 msgstr "Walloon"
 
-#: app/templates/alignment/enter.html:255
-#: app/templates/alignment/enter.html:400
+#: app/templates/alignment/enter.html:284
+#: app/templates/alignment/enter.html:429
 msgid "Welsh"
 msgstr "Welsh"
 
-#: app/templates/alignment/enter.html:256
-#: app/templates/alignment/enter.html:401
+#: app/templates/alignment/enter.html:285
+#: app/templates/alignment/enter.html:430
 msgid "Yiddish"
 msgstr "Yiddish"
 
-#: app/templates/alignment/enter.html:260
-#: app/templates/alignment/enter.html:405
+#: app/templates/alignment/enter.html:289
+#: app/templates/alignment/enter.html:434
 msgid "Other*:"
 msgstr "Autre*:"
 
-#: app/templates/alignment/enter.html:265
-#: app/templates/alignment/enter.html:410
-#: app/templates/treebank/enter.html:112
+#: app/templates/alignment/enter.html:294
+#: app/templates/alignment/enter.html:439 app/templates/treebank/enter.html:112
 msgid "Click  to toggle advanced options..."
 msgstr "Cliquer pour afficher les fonctions avancées"
 
-#: app/templates/alignment/enter.html:271
+#: app/templates/alignment/enter.html:300
 msgid "Language 2:"
 msgstr "Langue 2:"
 
-#: app/templates/alignment/enter.html:314
+#: app/templates/alignment/enter.html:343
 msgid "French (Old, 842-c. 1400)"
 msgstr "French (Old, 842-c. 1400)"
 
-#: app/templates/alignment/enter.html:415
-msgid "*Please use ISO 639-2 or ISO 639-3 three-letter codes for any other languages"
-msgstr "*Please use ISO 639-2 or ISO 639-3 three-letter codes for any other languages"
+#: app/templates/alignment/enter.html:444
+msgid ""
+"*Please use ISO 639-2 or ISO 639-3 three-letter codes for any other "
+"languages"
+msgstr ""
+"*Please use ISO 639-2 or ISO 639-3 three-letter codes for any other "
+"languages"
 
-#: app/templates/alignment/enter.html:419
+#: app/templates/alignment/enter.html:448
 msgid "Align"
 msgstr "Align"
 
@@ -763,10 +787,6 @@ msgstr "Chercher un texte"
 #: app/templates/treebank/enter.html:72
 msgid "Enter your own text URI :"
 msgstr "Entrer une addresse particulière pour un texte:"
-
-#: app/templates/treebank/enter.html:78
-msgid "Select"
-msgstr "Sélectionner"
 
 #: app/templates/treebank/enter.html:87
 msgid "Language:"
@@ -819,4 +839,7 @@ msgstr "Fournir l'adresse url du template de treebank"
 #: app/templates/treebank/enter.html:163
 msgid "Create Link"
 msgstr "Créer un lien"
+
+#~ msgid "Text URI"
+#~ msgstr "Text URI"
 

--- a/app/views.py
+++ b/app/views.py
@@ -24,6 +24,15 @@ def treebank():
        cts=configurator.get("cts")
      )
 
+@app.route('/thematic')
+def thematic():
+    return render_template(
+       'treebank/theme.html',
+       treebank=configurator.get("treebank"),
+       session=configurator.get("session"),
+       cts=configurator.get("cts")
+     )
+
 @app.route('/alignment')
 def alignment():
     return render_template(

--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-03-27 13:25+0000\n"
+"POT-Creation-Date: 2015-04-13 18:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,728 +17,752 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 1.3\n"
 
-#: app/templates/alignment/enter.html:77
+#: app/templates/alignment/enter.html:72
+msgid "Switch to prior version of this form"
+msgstr ""
+
+#: app/templates/alignment/enter.html:82
 msgid "Enter Metadata:"
 msgstr ""
 
-#: app/templates/alignment/enter.html:78
+#: app/templates/alignment/enter.html:83
 msgid "Alignment title:"
 msgstr ""
 
-#: app/templates/alignment/enter.html:78
+#: app/templates/alignment/enter.html:83
 msgid "alignmenttitlehint"
 msgstr ""
 
-#: app/templates/alignment/enter.html:79
+#: app/templates/alignment/enter.html:84
 msgid "Enter a short title for your annotation"
 msgstr ""
 
-#: app/templates/alignment/enter.html:85
+#: app/templates/alignment/enter.html:90
 msgid "Enter Text in Language 1:"
 msgstr ""
 
-#: app/templates/alignment/enter.html:87 app/templates/alignment/enter.html:107
+#: app/templates/alignment/enter.html:92 app/templates/alignment/enter.html:124
 #: app/templates/treebank/enter.html:98
 msgid "Text Direction:"
 msgstr ""
 
-#: app/templates/alignment/enter.html:89 app/templates/alignment/enter.html:109
+#: app/templates/alignment/enter.html:94 app/templates/alignment/enter.html:126
 #: app/templates/treebank/enter.html:100
 msgid "Left to Right"
 msgstr ""
 
-#: app/templates/alignment/enter.html:91 app/templates/alignment/enter.html:111
+#: app/templates/alignment/enter.html:96 app/templates/alignment/enter.html:128
 #: app/templates/treebank/enter.html:102
 msgid "Right to Left"
 msgstr ""
 
-#: app/templates/alignment/enter.html:96 app/templates/alignment/enter.html:115
-#: app/templates/treebank/enter.html:65 app/templates/treebank/enter.html:81
+#: app/templates/alignment/enter.html:101
+#: app/templates/alignment/enter.html:118
+#: app/templates/alignment/enter.html:132
+#: app/templates/alignment/enter.html:148 app/templates/treebank/enter.html:65
+#: app/templates/treebank/enter.html:81
 msgid "Invalid entry"
 msgstr ""
 
-#: app/templates/alignment/enter.html:100
-#: app/templates/alignment/enter.html:118
-msgid "Text URI"
+#: app/templates/alignment/enter.html:105
+#: app/templates/alignment/enter.html:135
+msgid "Search for a text:"
 msgstr ""
 
-#: app/templates/alignment/enter.html:105
+#: app/templates/alignment/enter.html:106
+#: app/templates/alignment/enter.html:136
+msgid ""
+"URI Identifer for this text. If a URL, text will be loaded from there. "
+"Plain text only supported."
+msgstr ""
+
+#: app/templates/alignment/enter.html:109
+#: app/templates/alignment/enter.html:139
+msgid "Or enter your own text URI:"
+msgstr ""
+
+#: app/templates/alignment/enter.html:115
+#: app/templates/alignment/enter.html:145 app/templates/treebank/enter.html:78
+msgid "Select"
+msgstr ""
+
+#: app/templates/alignment/enter.html:122
 msgid "Enter Text in Language 2:"
 msgstr ""
 
-#: app/templates/alignment/enter.html:126
-msgid "Language 1:"
-msgstr ""
-
-#: app/templates/alignment/enter.html:128
-#: app/templates/alignment/enter.html:273
-msgid "English"
-msgstr ""
-
-#: app/templates/alignment/enter.html:129
-#: app/templates/alignment/enter.html:274 app/templates/treebank/enter.html:91
-msgid "Latin"
-msgstr ""
-
-#: app/templates/alignment/enter.html:130
-#: app/templates/alignment/enter.html:275
-msgid "Greek (Ancient -1453)"
-msgstr ""
-
-#: app/templates/alignment/enter.html:131
-#: app/templates/alignment/enter.html:276 app/templates/treebank/enter.html:93
-msgid "Arabic"
-msgstr ""
-
-#: app/templates/alignment/enter.html:132
-#: app/templates/alignment/enter.html:277
-msgid "Chinese"
-msgstr ""
-
-#: app/templates/alignment/enter.html:133
-#: app/templates/alignment/enter.html:278
-msgid "Afrikaans"
-msgstr ""
-
-#: app/templates/alignment/enter.html:134
-#: app/templates/alignment/enter.html:279
-msgid "Akkadian"
-msgstr ""
-
-#: app/templates/alignment/enter.html:135
-#: app/templates/alignment/enter.html:280
-msgid "Albanian"
-msgstr ""
-
-#: app/templates/alignment/enter.html:136
-#: app/templates/alignment/enter.html:281
-msgid "Amharic"
-msgstr ""
-
-#: app/templates/alignment/enter.html:137
-#: app/templates/alignment/enter.html:282
-msgid "Aragonese"
-msgstr ""
-
-#: app/templates/alignment/enter.html:138
-#: app/templates/alignment/enter.html:283
-msgid "Aramaic (Imperial- 700 BC-300 BC)"
-msgstr ""
-
-#: app/templates/alignment/enter.html:139
-#: app/templates/alignment/enter.html:284
-msgid "Aramaic (Samaritan)"
-msgstr ""
-
-#: app/templates/alignment/enter.html:140
-#: app/templates/alignment/enter.html:285
-msgid "Armenian"
-msgstr ""
-
-#: app/templates/alignment/enter.html:141
-#: app/templates/alignment/enter.html:286
-msgid "Asturian (Bable, Leonese)"
-msgstr ""
-
-#: app/templates/alignment/enter.html:142
-#: app/templates/alignment/enter.html:287
-msgid "Avestan"
-msgstr ""
-
-#: app/templates/alignment/enter.html:143
-#: app/templates/alignment/enter.html:288
-msgid "Azerbaijani"
-msgstr ""
-
-#: app/templates/alignment/enter.html:144
-#: app/templates/alignment/enter.html:289
-msgid "Basque"
-msgstr ""
-
-#: app/templates/alignment/enter.html:145
-#: app/templates/alignment/enter.html:290
-msgid "Bengali"
-msgstr ""
-
-#: app/templates/alignment/enter.html:146
-#: app/templates/alignment/enter.html:291
-msgid "Berber"
-msgstr ""
-
-#: app/templates/alignment/enter.html:147
-#: app/templates/alignment/enter.html:292
-msgid "Bosnian"
-msgstr ""
-
-#: app/templates/alignment/enter.html:148
-#: app/templates/alignment/enter.html:293
-msgid "Breton"
-msgstr ""
-
-#: app/templates/alignment/enter.html:149
-#: app/templates/alignment/enter.html:294
-msgid "Bulgarian"
-msgstr ""
-
-#: app/templates/alignment/enter.html:150
-#: app/templates/alignment/enter.html:295
-msgid "Bulgarian (Old, Old Church Slavonic)"
-msgstr ""
-
-#: app/templates/alignment/enter.html:151
-#: app/templates/alignment/enter.html:296
-msgid "Burmese"
-msgstr ""
-
-#: app/templates/alignment/enter.html:152
-#: app/templates/alignment/enter.html:297
-msgid "Catalan"
-msgstr ""
-
-#: app/templates/alignment/enter.html:153
-#: app/templates/alignment/enter.html:298
-msgid "Chagatai"
-msgstr ""
-
-#: app/templates/alignment/enter.html:154
-#: app/templates/alignment/enter.html:299
-msgid "Coptic"
-msgstr ""
-
 #: app/templates/alignment/enter.html:155
-#: app/templates/alignment/enter.html:300
-msgid "Cornish"
-msgstr ""
-
-#: app/templates/alignment/enter.html:156
-#: app/templates/alignment/enter.html:301
-msgid "Croatian"
+msgid "Language 1:"
 msgstr ""
 
 #: app/templates/alignment/enter.html:157
 #: app/templates/alignment/enter.html:302
-msgid "Czech"
+msgid "English"
 msgstr ""
 
 #: app/templates/alignment/enter.html:158
-#: app/templates/alignment/enter.html:303
-msgid "Danish"
+#: app/templates/alignment/enter.html:303 app/templates/treebank/enter.html:91
+msgid "Latin"
 msgstr ""
 
 #: app/templates/alignment/enter.html:159
 #: app/templates/alignment/enter.html:304
-msgid "Dutch (Flemish)"
+msgid "Greek (Ancient -1453)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:160
-#: app/templates/alignment/enter.html:305
-msgid "Dutch (Middle, 1050-1350)"
+#: app/templates/alignment/enter.html:305 app/templates/treebank/enter.html:93
+msgid "Arabic"
 msgstr ""
 
 #: app/templates/alignment/enter.html:161
 #: app/templates/alignment/enter.html:306
-msgid "Egyptian (Ancient)"
+msgid "Chinese"
 msgstr ""
 
 #: app/templates/alignment/enter.html:162
 #: app/templates/alignment/enter.html:307
-msgid "Elamite"
+msgid "Afrikaans"
 msgstr ""
 
 #: app/templates/alignment/enter.html:163
 #: app/templates/alignment/enter.html:308
-msgid "English (Middle, 1100-1500)"
+msgid "Akkadian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:164
 #: app/templates/alignment/enter.html:309
-msgid "English (Old, 450-1100)"
+msgid "Albanian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:165
 #: app/templates/alignment/enter.html:310
-msgid "Estonian"
+msgid "Amharic"
 msgstr ""
 
 #: app/templates/alignment/enter.html:166
 #: app/templates/alignment/enter.html:311
-msgid "Finnish"
+msgid "Aragonese"
 msgstr ""
 
 #: app/templates/alignment/enter.html:167
 #: app/templates/alignment/enter.html:312
-msgid "French"
+msgid "Aramaic (Imperial- 700 BC-300 BC)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:168
 #: app/templates/alignment/enter.html:313
-msgid "French (Middle, 1400-1600)"
+msgid "Aramaic (Samaritan)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:169
-msgid "French (Old, 842c. 1400)"
+#: app/templates/alignment/enter.html:314
+msgid "Armenian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:170
 #: app/templates/alignment/enter.html:315
-msgid "Ge'ez"
+msgid "Asturian (Bable, Leonese)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:171
 #: app/templates/alignment/enter.html:316
-msgid "Georgian"
+msgid "Avestan"
 msgstr ""
 
 #: app/templates/alignment/enter.html:172
 #: app/templates/alignment/enter.html:317
-msgid "German (Low, Low Saxon)"
+msgid "Azerbaijani"
 msgstr ""
 
 #: app/templates/alignment/enter.html:173
 #: app/templates/alignment/enter.html:318
-msgid "German (Middle-High, 1050-1500)"
+msgid "Basque"
 msgstr ""
 
 #: app/templates/alignment/enter.html:174
 #: app/templates/alignment/enter.html:319
-msgid "German (Old-High, 750-1050)"
+msgid "Bengali"
 msgstr ""
 
 #: app/templates/alignment/enter.html:175
 #: app/templates/alignment/enter.html:320
-msgid "German"
+msgid "Berber"
 msgstr ""
 
 #: app/templates/alignment/enter.html:176
 #: app/templates/alignment/enter.html:321
-msgid "Gothic"
+msgid "Bosnian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:177
 #: app/templates/alignment/enter.html:322
-msgid "Greek (Modern, 1453-)"
+msgid "Breton"
 msgstr ""
 
 #: app/templates/alignment/enter.html:178
 #: app/templates/alignment/enter.html:323
-msgid "Gujarati"
+msgid "Bulgarian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:179
 #: app/templates/alignment/enter.html:324
-msgid "Hebrew"
+msgid "Bulgarian (Old, Old Church Slavonic)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:180
 #: app/templates/alignment/enter.html:325
-msgid "Hindi"
+msgid "Burmese"
 msgstr ""
 
 #: app/templates/alignment/enter.html:181
 #: app/templates/alignment/enter.html:326
-msgid "Hittite"
+msgid "Catalan"
 msgstr ""
 
 #: app/templates/alignment/enter.html:182
 #: app/templates/alignment/enter.html:327
-msgid "Hungarian"
+msgid "Chagatai"
 msgstr ""
 
 #: app/templates/alignment/enter.html:183
 #: app/templates/alignment/enter.html:328
-msgid "Icelandic"
+msgid "Coptic"
 msgstr ""
 
 #: app/templates/alignment/enter.html:184
 #: app/templates/alignment/enter.html:329
-msgid "Indonesian"
+msgid "Cornish"
 msgstr ""
 
 #: app/templates/alignment/enter.html:185
 #: app/templates/alignment/enter.html:330
-msgid "Irish (Modern)"
+msgid "Croatian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:186
 #: app/templates/alignment/enter.html:331
-msgid "Irish (Middle 900-1200)"
+msgid "Czech"
 msgstr ""
 
 #: app/templates/alignment/enter.html:187
 #: app/templates/alignment/enter.html:332
-msgid "Irish (Old, to 900)"
+msgid "Danish"
 msgstr ""
 
 #: app/templates/alignment/enter.html:188
 #: app/templates/alignment/enter.html:333
-msgid "Italian"
+msgid "Dutch (Flemish)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:189
 #: app/templates/alignment/enter.html:334
-msgid "Japanese"
+msgid "Dutch (Middle, 1050-1350)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:190
 #: app/templates/alignment/enter.html:335
-msgid "Javanese"
+msgid "Egyptian (Ancient)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:191
 #: app/templates/alignment/enter.html:336
-msgid "Kannada"
+msgid "Elamite"
 msgstr ""
 
 #: app/templates/alignment/enter.html:192
 #: app/templates/alignment/enter.html:337
-msgid "Khmer (Central)"
+msgid "English (Middle, 1100-1500)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:193
 #: app/templates/alignment/enter.html:338
-msgid "Korean"
+msgid "English (Old, 450-1100)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:194
 #: app/templates/alignment/enter.html:339
-msgid "Kurdish"
+msgid "Estonian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:195
 #: app/templates/alignment/enter.html:340
-msgid "Ladino"
+msgid "Finnish"
 msgstr ""
 
 #: app/templates/alignment/enter.html:196
 #: app/templates/alignment/enter.html:341
-msgid "Lithuanian"
+msgid "French"
 msgstr ""
 
 #: app/templates/alignment/enter.html:197
 #: app/templates/alignment/enter.html:342
-msgid "Malay"
+msgid "French (Middle, 1400-1600)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:198
-#: app/templates/alignment/enter.html:343
-msgid "Marathi"
+msgid "French (Old, 842c. 1400)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:199
 #: app/templates/alignment/enter.html:344
-msgid "Nepal Bhasa (Newari)"
+msgid "Ge'ez"
 msgstr ""
 
 #: app/templates/alignment/enter.html:200
 #: app/templates/alignment/enter.html:345
-msgid "Nepali"
+msgid "Georgian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:201
 #: app/templates/alignment/enter.html:346
-msgid "Newari (Classical)"
+msgid "German (Low, Low Saxon)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:202
 #: app/templates/alignment/enter.html:347
-msgid "Norse (Old)"
+msgid "German (Middle-High, 1050-1500)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:203
 #: app/templates/alignment/enter.html:348
-msgid "Norwegian"
+msgid "German (Old-High, 750-1050)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:204
 #: app/templates/alignment/enter.html:349
-msgid "Norwegian (Bokmål)"
+msgid "German"
 msgstr ""
 
 #: app/templates/alignment/enter.html:205
 #: app/templates/alignment/enter.html:350
-msgid "Norwegian (Nynorsk)"
+msgid "Gothic"
 msgstr ""
 
 #: app/templates/alignment/enter.html:206
 #: app/templates/alignment/enter.html:351
-msgid "Ossetian"
+msgid "Greek (Modern, 1453-)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:207
 #: app/templates/alignment/enter.html:352
-msgid "Pahlavi (Middle Persian)"
+msgid "Gujarati"
 msgstr ""
 
 #: app/templates/alignment/enter.html:208
 #: app/templates/alignment/enter.html:353
-msgid "Pali"
+msgid "Hebrew"
 msgstr ""
 
 #: app/templates/alignment/enter.html:209
 #: app/templates/alignment/enter.html:354
-msgid "Pashto"
+msgid "Hindi"
 msgstr ""
 
 #: app/templates/alignment/enter.html:210
 #: app/templates/alignment/enter.html:355
-msgid "Persian (Farsi)"
+msgid "Hittite"
 msgstr ""
 
 #: app/templates/alignment/enter.html:211
 #: app/templates/alignment/enter.html:356
-msgid "Persian (Old, 600-400 BC)"
+msgid "Hungarian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:212
 #: app/templates/alignment/enter.html:357
-msgid "Phoenician"
+msgid "Icelandic"
 msgstr ""
 
 #: app/templates/alignment/enter.html:213
 #: app/templates/alignment/enter.html:358
-msgid "Polish"
+msgid "Indonesian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:214
 #: app/templates/alignment/enter.html:359
-msgid "Portuguese"
+msgid "Irish (Modern)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:215
 #: app/templates/alignment/enter.html:360
-msgid "Prakrit"
+msgid "Irish (Middle 900-1200)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:216
 #: app/templates/alignment/enter.html:361
-msgid "Provençal (Occitan, -1500)"
+msgid "Irish (Old, to 900)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:217
 #: app/templates/alignment/enter.html:362
-msgid "Punjabi (Panjabi)"
+msgid "Italian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:218
 #: app/templates/alignment/enter.html:363
-msgid "Rajasthani"
+msgid "Japanese"
 msgstr ""
 
 #: app/templates/alignment/enter.html:219
 #: app/templates/alignment/enter.html:364
-msgid "Romanian"
+msgid "Javanese"
 msgstr ""
 
 #: app/templates/alignment/enter.html:220
 #: app/templates/alignment/enter.html:365
-msgid "Romany"
+msgid "Kannada"
 msgstr ""
 
 #: app/templates/alignment/enter.html:221
 #: app/templates/alignment/enter.html:366
-msgid "Russian"
+msgid "Khmer (Central)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:222
 #: app/templates/alignment/enter.html:367
-msgid "Sanskrit"
+msgid "Korean"
 msgstr ""
 
 #: app/templates/alignment/enter.html:223
 #: app/templates/alignment/enter.html:368
-msgid "Scots"
+msgid "Kurdish"
 msgstr ""
 
 #: app/templates/alignment/enter.html:224
 #: app/templates/alignment/enter.html:369
-msgid "Scottish (Gaelic)"
+msgid "Ladino"
 msgstr ""
 
 #: app/templates/alignment/enter.html:225
 #: app/templates/alignment/enter.html:370
-msgid "Serbian"
+msgid "Lithuanian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:226
 #: app/templates/alignment/enter.html:371
-msgid "Sicilian"
+msgid "Malay"
 msgstr ""
 
 #: app/templates/alignment/enter.html:227
 #: app/templates/alignment/enter.html:372
-msgid "Sindhi"
+msgid "Marathi"
 msgstr ""
 
 #: app/templates/alignment/enter.html:228
 #: app/templates/alignment/enter.html:373
-msgid "Sinhalese (Sinhala)"
+msgid "Nepal Bhasa (Newari)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:229
 #: app/templates/alignment/enter.html:374
-msgid "Slovak"
+msgid "Nepali"
 msgstr ""
 
 #: app/templates/alignment/enter.html:230
 #: app/templates/alignment/enter.html:375
-msgid "Slovenian"
+msgid "Newari (Classical)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:231
 #: app/templates/alignment/enter.html:376
-msgid "Sogdian"
+msgid "Norse (Old)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:232
 #: app/templates/alignment/enter.html:377
-msgid "Spanish (Castilian)"
+msgid "Norwegian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:233
 #: app/templates/alignment/enter.html:378
-msgid "Sumerian"
+msgid "Norwegian (Bokmål)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:234
 #: app/templates/alignment/enter.html:379
-msgid "Swahili"
+msgid "Norwegian (Nynorsk)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:235
 #: app/templates/alignment/enter.html:380
-msgid "Swedish"
+msgid "Ossetian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:236
 #: app/templates/alignment/enter.html:381
-msgid "Swiss German (Alsatian)"
+msgid "Pahlavi (Middle Persian)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:237
 #: app/templates/alignment/enter.html:382
-msgid "Syriac (Classical)"
+msgid "Pali"
 msgstr ""
 
 #: app/templates/alignment/enter.html:238
 #: app/templates/alignment/enter.html:383
-msgid "Syriac (Northeastern, Neo-Aramaic)"
+msgid "Pashto"
 msgstr ""
 
 #: app/templates/alignment/enter.html:239
 #: app/templates/alignment/enter.html:384
-msgid "Tagalog"
+msgid "Persian (Farsi)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:240
 #: app/templates/alignment/enter.html:385
-msgid "Tajik"
+msgid "Persian (Old, 600-400 BC)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:241
 #: app/templates/alignment/enter.html:386
-msgid "Tamil"
+msgid "Phoenician"
 msgstr ""
 
 #: app/templates/alignment/enter.html:242
 #: app/templates/alignment/enter.html:387
-msgid "Tatar"
+msgid "Polish"
 msgstr ""
 
 #: app/templates/alignment/enter.html:243
 #: app/templates/alignment/enter.html:388
-msgid "Telugu"
+msgid "Portuguese"
 msgstr ""
 
 #: app/templates/alignment/enter.html:244
 #: app/templates/alignment/enter.html:389
-msgid "Thai"
+msgid "Prakrit"
 msgstr ""
 
 #: app/templates/alignment/enter.html:245
 #: app/templates/alignment/enter.html:390
-msgid "Tibetan"
+msgid "Provençal (Occitan, -1500)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:246
 #: app/templates/alignment/enter.html:391
-msgid "Turkish (Modern)"
+msgid "Punjabi (Panjabi)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:247
 #: app/templates/alignment/enter.html:392
-msgid "Turkish (Ottoman, 1500-1928 )"
+msgid "Rajasthani"
 msgstr ""
 
 #: app/templates/alignment/enter.html:248
 #: app/templates/alignment/enter.html:393
-msgid "Turkmen"
+msgid "Romanian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:249
 #: app/templates/alignment/enter.html:394
-msgid "Ugaritic"
+msgid "Romany"
 msgstr ""
 
 #: app/templates/alignment/enter.html:250
 #: app/templates/alignment/enter.html:395
-msgid "Ukainian"
+msgid "Russian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:251
 #: app/templates/alignment/enter.html:396
-msgid "Urdu"
+msgid "Sanskrit"
 msgstr ""
 
 #: app/templates/alignment/enter.html:252
 #: app/templates/alignment/enter.html:397
-msgid "Uzbek"
+msgid "Scots"
 msgstr ""
 
 #: app/templates/alignment/enter.html:253
 #: app/templates/alignment/enter.html:398
-msgid "Vietnamese"
+msgid "Scottish (Gaelic)"
 msgstr ""
 
 #: app/templates/alignment/enter.html:254
 #: app/templates/alignment/enter.html:399
-msgid "Walloon"
+msgid "Serbian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:255
 #: app/templates/alignment/enter.html:400
-msgid "Welsh"
+msgid "Sicilian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:256
 #: app/templates/alignment/enter.html:401
-msgid "Yiddish"
+msgid "Sindhi"
+msgstr ""
+
+#: app/templates/alignment/enter.html:257
+#: app/templates/alignment/enter.html:402
+msgid "Sinhalese (Sinhala)"
+msgstr ""
+
+#: app/templates/alignment/enter.html:258
+#: app/templates/alignment/enter.html:403
+msgid "Slovak"
+msgstr ""
+
+#: app/templates/alignment/enter.html:259
+#: app/templates/alignment/enter.html:404
+msgid "Slovenian"
 msgstr ""
 
 #: app/templates/alignment/enter.html:260
 #: app/templates/alignment/enter.html:405
-msgid "Other*:"
+msgid "Sogdian"
+msgstr ""
+
+#: app/templates/alignment/enter.html:261
+#: app/templates/alignment/enter.html:406
+msgid "Spanish (Castilian)"
+msgstr ""
+
+#: app/templates/alignment/enter.html:262
+#: app/templates/alignment/enter.html:407
+msgid "Sumerian"
+msgstr ""
+
+#: app/templates/alignment/enter.html:263
+#: app/templates/alignment/enter.html:408
+msgid "Swahili"
+msgstr ""
+
+#: app/templates/alignment/enter.html:264
+#: app/templates/alignment/enter.html:409
+msgid "Swedish"
 msgstr ""
 
 #: app/templates/alignment/enter.html:265
-#: app/templates/alignment/enter.html:410 app/templates/treebank/enter.html:112
-msgid "Click  to toggle advanced options..."
+#: app/templates/alignment/enter.html:410
+msgid "Swiss German (Alsatian)"
+msgstr ""
+
+#: app/templates/alignment/enter.html:266
+#: app/templates/alignment/enter.html:411
+msgid "Syriac (Classical)"
+msgstr ""
+
+#: app/templates/alignment/enter.html:267
+#: app/templates/alignment/enter.html:412
+msgid "Syriac (Northeastern, Neo-Aramaic)"
+msgstr ""
+
+#: app/templates/alignment/enter.html:268
+#: app/templates/alignment/enter.html:413
+msgid "Tagalog"
+msgstr ""
+
+#: app/templates/alignment/enter.html:269
+#: app/templates/alignment/enter.html:414
+msgid "Tajik"
+msgstr ""
+
+#: app/templates/alignment/enter.html:270
+#: app/templates/alignment/enter.html:415
+msgid "Tamil"
 msgstr ""
 
 #: app/templates/alignment/enter.html:271
+#: app/templates/alignment/enter.html:416
+msgid "Tatar"
+msgstr ""
+
+#: app/templates/alignment/enter.html:272
+#: app/templates/alignment/enter.html:417
+msgid "Telugu"
+msgstr ""
+
+#: app/templates/alignment/enter.html:273
+#: app/templates/alignment/enter.html:418
+msgid "Thai"
+msgstr ""
+
+#: app/templates/alignment/enter.html:274
+#: app/templates/alignment/enter.html:419
+msgid "Tibetan"
+msgstr ""
+
+#: app/templates/alignment/enter.html:275
+#: app/templates/alignment/enter.html:420
+msgid "Turkish (Modern)"
+msgstr ""
+
+#: app/templates/alignment/enter.html:276
+#: app/templates/alignment/enter.html:421
+msgid "Turkish (Ottoman, 1500-1928 )"
+msgstr ""
+
+#: app/templates/alignment/enter.html:277
+#: app/templates/alignment/enter.html:422
+msgid "Turkmen"
+msgstr ""
+
+#: app/templates/alignment/enter.html:278
+#: app/templates/alignment/enter.html:423
+msgid "Ugaritic"
+msgstr ""
+
+#: app/templates/alignment/enter.html:279
+#: app/templates/alignment/enter.html:424
+msgid "Ukainian"
+msgstr ""
+
+#: app/templates/alignment/enter.html:280
+#: app/templates/alignment/enter.html:425
+msgid "Urdu"
+msgstr ""
+
+#: app/templates/alignment/enter.html:281
+#: app/templates/alignment/enter.html:426
+msgid "Uzbek"
+msgstr ""
+
+#: app/templates/alignment/enter.html:282
+#: app/templates/alignment/enter.html:427
+msgid "Vietnamese"
+msgstr ""
+
+#: app/templates/alignment/enter.html:283
+#: app/templates/alignment/enter.html:428
+msgid "Walloon"
+msgstr ""
+
+#: app/templates/alignment/enter.html:284
+#: app/templates/alignment/enter.html:429
+msgid "Welsh"
+msgstr ""
+
+#: app/templates/alignment/enter.html:285
+#: app/templates/alignment/enter.html:430
+msgid "Yiddish"
+msgstr ""
+
+#: app/templates/alignment/enter.html:289
+#: app/templates/alignment/enter.html:434
+msgid "Other*:"
+msgstr ""
+
+#: app/templates/alignment/enter.html:294
+#: app/templates/alignment/enter.html:439 app/templates/treebank/enter.html:112
+msgid "Click  to toggle advanced options..."
+msgstr ""
+
+#: app/templates/alignment/enter.html:300
 msgid "Language 2:"
 msgstr ""
 
-#: app/templates/alignment/enter.html:314
+#: app/templates/alignment/enter.html:343
 msgid "French (Old, 842-c. 1400)"
 msgstr ""
 
-#: app/templates/alignment/enter.html:415
+#: app/templates/alignment/enter.html:444
 msgid ""
 "*Please use ISO 639-2 or ISO 639-3 three-letter codes for any other "
 "languages"
 msgstr ""
 
-#: app/templates/alignment/enter.html:419
+#: app/templates/alignment/enter.html:448
 msgid "Align"
 msgstr ""
 
@@ -756,10 +780,6 @@ msgstr ""
 
 #: app/templates/treebank/enter.html:72
 msgid "Enter your own text URI :"
-msgstr ""
-
-#: app/templates/treebank/enter.html:78
-msgid "Select"
 msgstr ""
 
 #: app/templates/treebank/enter.html:87

--- a/run.py
+++ b/run.py
@@ -1,3 +1,3 @@
-#!flask/bin/python3
+#!flask/bin/python3.4
 from app import app
 app.run(debug=True, host="0.0.0.0")


### PR DESCRIPTION
- edit.utils putContents now works across domains (and thus is no longer a syncrhonous ajax call, which isn't supported withCredentials=true)
- alignment editor input form supports user-supplied uris
- paths in the configurations reflect production deployment below the root of the web server (but probably this should be handled differently, maybe with a setting which defines the deployment root, and then is used in other settings?)